### PR TITLE
Lua API & REPL using luagenny

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,12 +51,12 @@ FetchContent_Declare(sdkgenny
 )
 FetchContent_MakeAvailable(sdkgenny)
 
-message(STATUS "Fetching luagenny (e1e2138eb24481687ad642d449ce47b758e00c8c)...")
+message(STATUS "Fetching luagenny (5cdafd93b175a5aca92b5de935aa5c702a3b6ee7)...")
 FetchContent_Declare(luagenny
 	GIT_REPOSITORY
 		"https://github.com/praydog/luagenny.git"
 	GIT_TAG
-		e1e2138eb24481687ad642d449ce47b758e00c8c
+		5cdafd93b175a5aca92b5de935aa5c702a3b6ee7
 )
 FetchContent_MakeAvailable(luagenny)
 
@@ -183,16 +183,9 @@ target_link_libraries(regenny PRIVATE
 	glad::glad
 	sdkgenny::sdkgenny
 	lua
-	sol2::sol2
+	sol2
 	luagenny::luagenny
 )
-
-if(${VCPKG_TARGET_TRIPLET} MATCHES ".+static") # static
-	set_target_properties(regenny PROPERTIES
-		MSVC_RUNTIME_LIBRARY
-			"MultiThreaded$<$<CONFIG:Debug>:Debug>"
-	)
-endif()
 
 unset(CMKR_TARGET)
 unset(CMKR_SOURCES)
@@ -230,11 +223,3 @@ target_compile_features(test0 PRIVATE
 unset(CMKR_TARGET)
 unset(CMKR_SOURCES)
 
-install(
-	TARGETS
-		regenny
-	DESTINATION
-		bin
-	COMPONENT
-		regenny
-)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,14 +42,23 @@ endif()
 
 include(FetchContent)
 
-message(STATUS "Fetching sdkgenny (f03026eaced3bd033e201bc7d1c9d9d348054113)...")
+message(STATUS "Fetching sdkgenny (eb06f76d72454394c4ef4f2da4fae05bb82db82a)...")
 FetchContent_Declare(sdkgenny
 	GIT_REPOSITORY
 		"https://github.com/cursey/sdkgenny.git"
 	GIT_TAG
-		f03026eaced3bd033e201bc7d1c9d9d348054113
+		eb06f76d72454394c4ef4f2da4fae05bb82db82a
 )
 FetchContent_MakeAvailable(sdkgenny)
+
+message(STATUS "Fetching luagenny (351c4f2bc9a99bf9e91a997d39fe3dca48713941)...")
+FetchContent_Declare(luagenny
+	GIT_REPOSITORY
+		"https://github.com/praydog/luagenny.git"
+	GIT_TAG
+		351c4f2bc9a99bf9e91a997d39fe3dca48713941
+)
+FetchContent_MakeAvailable(luagenny)
 
 # Packages
 find_package(imgui REQUIRED)
@@ -69,6 +78,10 @@ find_package(SDL2 REQUIRED)
 find_package(nlohmann_json REQUIRED)
 
 find_package(glad REQUIRED)
+
+find_package(sol2 REQUIRED)
+
+find_package(lua REQUIRED)
 
 # Target regenny
 set(CMKR_TARGET regenny)
@@ -169,6 +182,9 @@ target_link_libraries(regenny PRIVATE
 	nlohmann_json::nlohmann_json
 	glad::glad
 	sdkgenny::sdkgenny
+	lua
+	sol2::sol2
+	luagenny::luagenny
 )
 
 if(${VCPKG_TARGET_TRIPLET} MATCHES ".+static") # static

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,21 +42,21 @@ endif()
 
 include(FetchContent)
 
-message(STATUS "Fetching sdkgenny (eb06f76d72454394c4ef4f2da4fae05bb82db82a)...")
+message(STATUS "Fetching sdkgenny (2bf398fdcc48346486b0e754a93da21fb788e245)...")
 FetchContent_Declare(sdkgenny
 	GIT_REPOSITORY
 		"https://github.com/cursey/sdkgenny.git"
 	GIT_TAG
-		eb06f76d72454394c4ef4f2da4fae05bb82db82a
+		2bf398fdcc48346486b0e754a93da21fb788e245
 )
 FetchContent_MakeAvailable(sdkgenny)
 
-message(STATUS "Fetching luagenny (351c4f2bc9a99bf9e91a997d39fe3dca48713941)...")
+message(STATUS "Fetching luagenny (e1e2138eb24481687ad642d449ce47b758e00c8c)...")
 FetchContent_Declare(luagenny
 	GIT_REPOSITORY
 		"https://github.com/praydog/luagenny.git"
 	GIT_TAG
-		351c4f2bc9a99bf9e91a997d39fe3dca48713941
+		e1e2138eb24481687ad642d449ce47b758e00c8c
 )
 FetchContent_MakeAvailable(luagenny)
 

--- a/cmake.toml
+++ b/cmake.toml
@@ -19,7 +19,7 @@ packages = [
 
 [fetch-content]
 sdkgenny = { git = "https://github.com/cursey/sdkgenny.git", tag = "2bf398fdcc48346486b0e754a93da21fb788e245" }
-luagenny = { git = "https://github.com/praydog/luagenny.git", tag = "e1e2138eb24481687ad642d449ce47b758e00c8c" }
+luagenny = { git = "https://github.com/praydog/luagenny.git", tag = "5cdafd93b175a5aca92b5de935aa5c702a3b6ee7" }
 
 [find-package]
 imgui = {}
@@ -62,7 +62,7 @@ link-libraries = [
     "glad::glad",
     "sdkgenny::sdkgenny",
     "lua",
-    "sol2::sol2",
+    "sol2",
     "luagenny::luagenny",
 ]
 compile-definitions = ["UTF_CPP_CPLUSPLUS=201103L"]

--- a/cmake.toml
+++ b/cmake.toml
@@ -13,10 +13,13 @@ packages = [
     "utfcpp",
     "nlohmann-json",
     "glad[gl-api-30]",
+    "lua",
+    "sol2"
 ]
 
 [fetch-content]
-sdkgenny = { git = "https://github.com/cursey/sdkgenny.git", tag = "f03026eaced3bd033e201bc7d1c9d9d348054113" }
+sdkgenny = { git = "https://github.com/cursey/sdkgenny.git", tag = "eb06f76d72454394c4ef4f2da4fae05bb82db82a" }
+luagenny = { git = "https://github.com/praydog/luagenny.git", tag = "351c4f2bc9a99bf9e91a997d39fe3dca48713941" }
 
 [find-package]
 imgui = {}
@@ -28,6 +31,8 @@ utf8cpp = {}
 SDL2 = {}
 nlohmann_json = {}
 glad = {}
+sol2 = {}
+lua = {}
 
 [target.regenny]
 type = "executable"
@@ -56,6 +61,9 @@ link-libraries = [
     "nlohmann_json::nlohmann_json",
     "glad::glad",
     "sdkgenny::sdkgenny",
+    "lua",
+    "sol2::sol2",
+    "luagenny::luagenny",
 ]
 compile-definitions = ["UTF_CPP_CPLUSPLUS=201103L"]
 compile-features = ["cxx_std_17"]

--- a/cmake.toml
+++ b/cmake.toml
@@ -18,8 +18,8 @@ packages = [
 ]
 
 [fetch-content]
-sdkgenny = { git = "https://github.com/cursey/sdkgenny.git", tag = "eb06f76d72454394c4ef4f2da4fae05bb82db82a" }
-luagenny = { git = "https://github.com/praydog/luagenny.git", tag = "351c4f2bc9a99bf9e91a997d39fe3dca48713941" }
+sdkgenny = { git = "https://github.com/cursey/sdkgenny.git", tag = "2bf398fdcc48346486b0e754a93da21fb788e245" }
+luagenny = { git = "https://github.com/praydog/luagenny.git", tag = "e1e2138eb24481687ad642d449ce47b758e00c8c" }
 
 [find-package]
 imgui = {}

--- a/src/Process.hpp
+++ b/src/Process.hpp
@@ -53,6 +53,10 @@ public:
         return out;
     }
 
+    template <typename T> bool write(uintptr_t address, const T& value) {
+        return write(address, &value, sizeof(T));
+    }
+
 protected:
     std::vector<Module> m_modules{};
     std::vector<Allocation> m_allocations{};

--- a/src/ReGenny.cpp
+++ b/src/ReGenny.cpp
@@ -890,7 +890,17 @@ void ReGenny::reset_lua_state() {
         "read_int32", [](Process* p, uintptr_t addr) { return p->read<int32_t>(addr); },
         "read_int64", [](Process* p, uintptr_t addr) { return p->read<int64_t>(addr); },
         "read_float", [](Process* p, uintptr_t addr) { return p->read<float>(addr); },
-        "read_double", [](Process* p, uintptr_t addr) { return p->read<double>(addr); }
+        "read_double", [](Process* p, uintptr_t addr) { return p->read<double>(addr); },
+        "write_uint8", [](Process* p, uintptr_t addr, uint8_t val) { p->write<uint8_t>(addr, val); },
+        "write_uint16", [](Process* p, uintptr_t addr, uint16_t val) { p->write<uint16_t>(addr, val); },
+        "write_uint32", [](Process* p, uintptr_t addr, uint32_t val) { p->write<uint32_t>(addr, val); },
+        "write_uint64", [](Process* p, uintptr_t addr, uint64_t val) { p->write<uint64_t>(addr, val); },
+        "write_int8", [](Process* p, uintptr_t addr, int8_t val) { p->write<int8_t>(addr, val); },
+        "write_int16", [](Process* p, uintptr_t addr, int16_t val) { p->write<int16_t>(addr, val); },
+        "write_int32", [](Process* p, uintptr_t addr, int32_t val) { p->write<int32_t>(addr, val); },
+        "write_int64", [](Process* p, uintptr_t addr, int64_t val) { p->write<int64_t>(addr, val); },
+        "write_float", [](Process* p, uintptr_t addr, float val) { p->write<float>(addr, val); },
+        "write_double", [](Process* p, uintptr_t addr, double val) { p->write<double>(addr, val); }
     );
 
     lua["regenny"] = this;

--- a/src/ReGenny.hpp
+++ b/src/ReGenny.hpp
@@ -36,6 +36,7 @@ public:
     auto& sdk() const { return m_sdk; }
     auto type() const { return m_type; }
     auto& process() const { return m_process; }
+    auto address() const { return m_address; }
 
 private:
     int m_window_w{};

--- a/src/ReGenny.hpp
+++ b/src/ReGenny.hpp
@@ -35,6 +35,7 @@ public:
     auto& lua() const { return *m_lua; }
     auto& sdk() const { return m_sdk; }
     auto type() const { return m_type; }
+    auto& process() const { return m_process; }
 
 private:
     int m_window_w{};

--- a/src/ReGenny.hpp
+++ b/src/ReGenny.hpp
@@ -10,6 +10,7 @@
 
 #include <Genny.hpp>
 #include <SDL.h>
+#include <sol/sol.hpp>
 
 #include "Config.hpp"
 #include "Helpers.hpp"
@@ -31,6 +32,9 @@ public:
     void ui();
 
     auto&& window() const { return m_window; }
+    auto& lua() const { return *m_lua; }
+    auto& sdk() const { return m_sdk; }
+    auto type() const { return m_type; }
 
 private:
     int m_window_w{};
@@ -87,6 +91,9 @@ private:
     Config m_cfg{};
     std::optional<std::chrono::system_clock::time_point> m_cfg_save_time{};
 
+    std::recursive_mutex m_lua_lock{};
+    std::unique_ptr<sol::state> m_lua{};
+
     Project m_project{};
 
     void menu_ui();
@@ -114,6 +121,7 @@ private:
 
     void editor_ui();
     void parse_editor_text();
+    void reset_lua_state();
 
     void load_cfg();
     void save_cfg();

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -16,7 +16,9 @@
     {
       "name": "glad",
       "features": ["gl-api-30"]
-    }
+    },
+    "lua",
+    "sol2"
   ],
   "description": "",
   "name": "regenny",


### PR DESCRIPTION
As per the title, this adds a Lua API & REPL using my library, [luagenny](https://github.com/praydog/luagenny).

This adds three new dependencies, [sol2](https://github.com/ThePhD/sol2), [lua 5.4](https://github.com/lua/lua), and [luagenny](https://github.com/praydog/luagenny).

The top level luagenny API can be accessed through the `sdkgenny` global table.

ReGenny's implementation overrides luagenny's global `sdkgenny_reader` and `sdkgenny_string_reader` functions to read external memory instead.

In addition to the luagenny bindings, I've added bindings for some of the core regenny objects:

`ReGenny` class can be accessed by the Lua global `regenny`:
```lua
regenny:address() -- Returns the current top level structure address being inspected in the viewer/editor
regenny:type() -- Returns the current sdkgenny::Type* being inspected in the viewer/editor
regenny:sdk() -- Returns the current sdkgenny::Sdk* created as a result of parsing the editor text
regenny:process() -- Returns the current regenny Process* for the attached process, WindowsProcess* on Win32
regenny:overlay() -- Constructs and returns a new sdkgenny.StructOverlay with the current address() and type()
```

`Process` class: (read funcs only take (addr), write funcs are (addr, value))
* `read_uint8`
* `read_uint16`
* `read_uint32`
* `read_uint64`
* `read_int8`
* `read_int16`
* `read_int32`
* `read_int64`
* `read_float`
* `read_double`
* `write_uint8`
* `write_uint1`
* `write_uint3`
* `write_uint6`
* `write_int8`
* `write_int16`
* `write_int32`
* `write_int64`
* `write_float`
* `write_double`
* `read_string`

`WindowsProcess` class (on Windows only):
* `get_typename(obj_addr)` - Returns the RTTI name of the object

Example script to set the scale of a game object given the corret structure definitions:
```lua
if regenny:overlay:type():name() ~= "HeroLocal" then
    print("overlay is not a HeroLocal")
    return
end

function set_scale(x, y, z)
    local data = regenny:overlay().owner.data_at_0

    if data then
        data.scale.x = x
        data.scale.y = y
        data.scale.z = z
    end
end
```

Then just run `set_scale(1, 2, 3)` inside the REPL window.

Example script to dump component names for a given entity in that new game about the Arachnid Male (given the correct ReGenny structure definitions)

![arachnid](https://user-images.githubusercontent.com/2909949/186584544-e879f9d3-f3ed-4c48-9f9a-e9bbe88ab3f3.png)

```lua
local overlay = regenny:overlay()
if overlay == nil then
    print("no overlay, exiting")
    return
end

if overlay:type():name() ~= "HeroLocal" then
    print("overlay is not a HeroLocal")
    return
end

for i=0, 1000 do
    local elements = overlay.data[0].elements
    if elements == nil then
        print("elements is nil")
        break
    end

    local element = overlay.data[0].elements[i]
    if element == nil then
        print("element at " .. tostring(i) .. " is nil")
        break
    end
    
    local descriptor = element.descriptor
    local comp = element.component
    if comp == nil then
        print("Encountered nil component at index " .. tostring(i))
        break
    end

    if descriptor == nil then
        print("Encountered nil descriptor at index " .. tostring(i))
        break
    end

    local name = descriptor.component_name
    if name == nil then
        print("Encountered nil component name at index " .. tostring(i))
        break
    end

    local data = comp.data
    if data == nil then
        print("Encountered nil data at index " .. tostring(i))
        break
    end

    print(tostring(i) .. " [" .. tostring(data.component_name) .. "]: " .. name)
end
```