### PR TITLE
 Add the ability to seach modules with path 

### DIFF
--- a/src/ReGenny.cpp
+++ b/src/ReGenny.cpp
@@ -1033,7 +1033,10 @@ void ReGenny::update_address() {
         std::transform(modname.begin(), modname.end(), modname.begin(), tolower);
 
         for (auto&& mod : m_process->modules()) {
-            if (mod.name.ends_with(modname)) {
+            std::string name = mod.name;
+            std::transform(name.begin(), name.end(), name.begin(), tolower);
+
+            if (name.ends_with(modname)) {
                 m_address += mod.start;
                 break;
             }

--- a/src/ReGenny.cpp
+++ b/src/ReGenny.cpp
@@ -1029,10 +1029,10 @@ void ReGenny::update_address() {
 
     if (!m_parsed_address.name.empty()) {
         auto& modname = m_parsed_address.name;
+        std::transform(modname.begin(), modname.end(), modname.begin(), tolower);
 
         for (auto&& mod : m_process->modules()) {
-            if (std::equal(modname.begin(), modname.end(), mod.name.begin(), mod.name.end(),
-                    [](auto a, auto b) { return std::tolower(a) == std::tolower(b); })) {
+            if (mod.name.ends_with(modname)) {
                 m_address += mod.start;
                 break;
             }

--- a/src/ReGenny.cpp
+++ b/src/ReGenny.cpp
@@ -1029,7 +1029,7 @@ void ReGenny::update_address() {
     m_address = m_parsed_address.offsets.front();
 
     if (!m_parsed_address.name.empty()) {
-        auto& modname = m_parsed_address.name;
+        auto modname = m_parsed_address.name;
         std::transform(modname.begin(), modname.end(), modname.begin(), tolower);
 
         for (auto&& mod : m_process->modules()) {

--- a/src/Utility.cpp
+++ b/src/Utility.cpp
@@ -8,7 +8,7 @@ using namespace tao::pegtl;
 struct HexNum : seq<one<'0'>, one<'x'>, plus<xdigit>> {};
 struct DecNum : plus<digit> {};
 struct Num : sor<HexNum, DecNum> {};
-struct NameChar : sor<alnum, one<' ', '(', ')', '_', '-', ',', '.'>> {};
+struct NameChar : sor<alnum, one<' ', '(', ')', '_', '-', ',', '.', '/', '\\'>> {};
 struct Name : seq<plus<NameChar>> {};
 struct Offset : seq<Num, opt<one<'-'>, one<'>'>, struct Offset>> {};
 struct ModOffset : seq<one<'<'>, Name, one<'>'>, opt<one<'+'>, Offset>> {};

--- a/src/arch/Windows.cpp
+++ b/src/arch/Windows.cpp
@@ -31,10 +31,7 @@ WindowsProcess::WindowsProcess(DWORD process_id) : Process{} {
             do {
                 Module m{};
 
-                std::string path = entry.szExePath;
-                std::transform(path.begin(), path.end(), path.begin(), tolower);
-
-                m.name = path;
+                m.name = entry.szExePath;
                 m.start = (uintptr_t)entry.modBaseAddr;
                 m.size = entry.modBaseSize;
                 m.end = m.start + m.size;

--- a/src/arch/Windows.cpp
+++ b/src/arch/Windows.cpp
@@ -8,6 +8,8 @@
 
 #include "Windows.hpp"
 
+#include <algorithm>
+
 namespace arch {
 WindowsProcess::WindowsProcess(DWORD process_id) : Process{} {
     m_process = OpenProcess(
@@ -29,7 +31,10 @@ WindowsProcess::WindowsProcess(DWORD process_id) : Process{} {
             do {
                 Module m{};
 
-                m.name = entry.szModule;
+                std::string path = entry.szExePath;
+                std::transform(path.begin(), path.end(), path.begin(), tolower);
+
+                m.name = path;
                 m.start = (uintptr_t)entry.modBaseAddr;
                 m.size = entry.modBaseSize;
                 m.end = m.start + m.size;

--- a/src/arch/Windows.cpp
+++ b/src/arch/Windows.cpp
@@ -8,8 +8,6 @@
 
 #include "Windows.hpp"
 
-#include <algorithm>
-
 namespace arch {
 WindowsProcess::WindowsProcess(DWORD process_id) : Process{} {
     m_process = OpenProcess(


### PR DESCRIPTION
![image](https://github.com/cursey/regenny/assets/89713806/81b5e852-ba25-4aeb-aab7-da88d3a26f26)
When there are two or more modules with the same name but different path, searching with ``<module_name>+offset`` will only gives you the address of the first ``module_name``, this PR fixes this problem.

Searching with ``<csgo\bin\win64\server.dll>+0x0``:
![image](https://github.com/cursey/regenny/assets/89713806/5893b850-b494-44e8-bbab-4289e04a8dc5)
Searching with ``<metamod\bin\win64\server.dll>+0x0``:
![image](https://github.com/cursey/regenny/assets/89713806/9617e453-bb42-43ad-8b1e-095f5064cf9b)

However when displaying an object, the mod name will display the path instead of mod name, please let me know if this needs to be changed
![image](https://github.com/cursey/regenny/assets/89713806/5f35c6a2-6330-4903-9e4d-4cf76976393a)
