### PR TITLE
Rudimentary Linux support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,13 @@ add_subdirectory(third_party)
 # regenny
 #
 file(GLOB_RECURSE regenny_sources "src/*")
+
+if(MSVC)
+    list(FILTER regenny_sources EXCLUDE REGEX "src/arch/Linux.cpp$")
+else()
+    list(FILTER regenny_sources EXCLUDE REGEX "src/arch/Windows.cpp$")
+endif()
+
 add_executable(regenny ${regenny_sources})
 target_include_directories(regenny PRIVATE "src")
 target_link_libraries(regenny PRIVATE

--- a/src/Helpers.hpp
+++ b/src/Helpers.hpp
@@ -6,5 +6,6 @@
 
 class Helpers {
 public:
+    virtual ~Helpers() = default;
     virtual std::map<uint32_t, std::string> processes() = 0;
 };

--- a/src/Process.cpp
+++ b/src/Process.cpp
@@ -1,5 +1,7 @@
 #include "Process.hpp"
 
+#include <cstring>
+
 bool Process::read(uintptr_t address, void* buffer, size_t size) {
     // If we're reading from read-only memory we can just use the cached version since it hasn't changed.
     for (auto&& ro_allocation : m_read_only_allocations) {

--- a/src/Process.hpp
+++ b/src/Process.hpp
@@ -7,6 +7,8 @@
 
 class Process {
 public:
+    virtual ~Process() = default;
+    
     class Module {
     public:
         std::string name{};

--- a/src/arch/Arch.cpp
+++ b/src/arch/Arch.cpp
@@ -1,5 +1,7 @@
 #ifdef _WIN32
 #include "Windows.hpp"
+#else
+#include "Linux.hpp"
 #endif
 
 #include "Arch.hpp"
@@ -7,11 +9,15 @@
 std::unique_ptr<Helpers> arch::make_helpers() {
 #ifdef _WIN32
     return std::make_unique<arch::WindowsHelpers>();
+#else
+    return std::make_unique<arch::LinuxHelpers>();
 #endif
 }
 
 std::unique_ptr<Process> arch::open_process(uint32_t process_id) {
 #ifdef _WIN32
     return std::make_unique<arch::WindowsProcess>(process_id);
+#else
+    return std::make_unique<arch::LinuxProcess>(process_id);
 #endif
 }

--- a/src/arch/Linux.cpp
+++ b/src/arch/Linux.cpp
@@ -1,0 +1,164 @@
+#include "Linux.hpp"
+
+#include <algorithm>
+#include <array>
+#include <cassert>
+#include <charconv>
+#include <csignal>
+#include <cstddef>
+#include <cstdint>
+#include <cstdio>
+#include <fcntl.h>
+#include <filesystem>
+#include <fstream>
+#include <map>
+#include <optional>
+#include <signal.h>
+#include <string>
+#include <string_view>
+#include <sys/types.h>
+#include <system_error>
+#include <unistd.h>
+#include <utility>
+#include <vector>
+
+namespace arch {
+
+LinuxProcess::LinuxProcess(pid_t process_id) : m_process(process_id) {
+    std::string path = "/proc/" + std::to_string(process_id) + "/mem";
+    rw_handle = open(path.c_str(), O_RDWR);
+    assert(rw_handle >= 0); // TODO better error handling
+
+    std::fstream maps{"/proc/" + std::to_string(process_id) + "/maps", std::fstream::in};
+    assert(maps);
+
+    for (std::string line; std::getline(maps, line);) {
+        if (line.empty())
+            continue; // ?
+
+        std::uintptr_t begin = 0;
+        std::uintptr_t end = 0;
+        std::array<char, 3> perms{};
+        char shared = 0;
+        std::string name;
+
+        int offset = -1;
+
+        sscanf(line.c_str(), "%zx-%zx %c%c%c%c %*x %*x:%*x %*x%n", &begin, &end, &perms[0], &perms[1], &perms[2],
+            &shared, &offset);
+
+        while (offset < line.length() && line[offset] == ' ')
+            offset++;
+        if (offset < line.length())
+            name = line.c_str() + offset;
+
+        if (!name.empty()) {
+            constexpr static const char* DELETED_TAG = " (deleted)";
+            constexpr static std::size_t DELETED_TAG_LEN = std::char_traits<char>::length(DELETED_TAG);
+            if (name.ends_with(DELETED_TAG)) {
+                name = name.substr(0, name.length() - DELETED_TAG_LEN);
+            }
+
+            if (name[0] == '[') {
+                perms[0] = '-';
+            }
+        }
+
+        if (!name.empty()) {
+            auto it = std::ranges::find_if(m_modules, [&name](Module& module) { return module.name == name; });
+
+            if (it == m_modules.end()) {
+                m_modules.emplace_back(name, begin, end, end - begin);
+            } else {
+                it->start = std::min(it->start, begin);
+                it->end = std::min(it->end, end);
+                it->size = it->end - it->start;
+            }
+        }
+
+        m_allocations.emplace_back(begin, end, end - begin, perms[0] == 'r', perms[1] == 'w', perms[2] == 'x');
+
+        if (perms[0] == 'r') {
+            ReadOnlyAllocation ro_alloc{
+                Allocation(begin, end, end - begin, perms[0] == 'r', perms[1] == 'w', perms[2] == 'x'), {}};
+
+            ro_alloc.mem.reserve(end - begin);
+
+            if (read(begin, ro_alloc.mem.data(), end - begin)) {
+                m_read_only_allocations.emplace_back(std::move(ro_alloc));
+            }
+        }
+    }
+
+    maps.close();
+}
+
+uint32_t LinuxProcess::process_id() {
+    return m_process;
+}
+
+bool LinuxProcess::ok() {
+    return kill(m_process, 0) == 0;
+}
+
+std::optional<std::string> LinuxProcess::get_typename(uintptr_t ptr) {
+    // TODO
+    return {};
+}
+std::optional<std::string> LinuxProcess::get_typename_from_vtable(uintptr_t ptr) {
+    // TODO
+    return {};
+}
+
+bool LinuxProcess::handle_write(uintptr_t address, const void* buffer, size_t size) {
+    return pwrite(rw_handle, buffer, size, address) == static_cast<int>(size);
+}
+bool LinuxProcess::handle_read(uintptr_t address, void* buffer, size_t size) {
+    return pread(rw_handle, buffer, size, address) == static_cast<int>(size);
+}
+std::optional<uint64_t> LinuxProcess::handle_protect(uintptr_t address, size_t size, uint64_t flags) {
+    // TODO
+    return {};
+}
+std::optional<uintptr_t> LinuxProcess::handle_allocate(uintptr_t address, size_t size, uint64_t flags) {
+    // TODO
+    return {};
+}
+
+std::map<uint32_t, std::string> LinuxHelpers::processes() {
+    std::map<std::uint32_t, std::string> processes;
+    for (const std::filesystem::path& it : std::filesystem::directory_iterator{"/proc"}) {
+        if (!std::filesystem::is_directory(it))
+            continue;
+
+        const std::string& str = it.filename();
+
+        pid_t pid;
+        auto result = std::from_chars(str.data(), str.data() + str.size(), pid);
+
+        if (result.ec != std::errc{})
+            continue;
+
+        std::ifstream f{"/proc/" + str + "/status"};
+
+        std::string name;
+
+        for (std::string line; std::getline(f, line);) {
+            static constexpr std::string_view PATTERN = "Name:";
+
+            if (line.starts_with(PATTERN)) {
+                name = line.substr(line.find_first_not_of(' ', PATTERN.length() + 1));
+                break;
+            }
+        }
+
+        f.close();
+        if (name.empty())
+            continue;
+
+        processes.insert({pid, name});
+    }
+    return processes;
+}
+
+} // namespace arch

--- a/src/arch/Linux.hpp
+++ b/src/arch/Linux.hpp
@@ -1,0 +1,38 @@
+#pragma once
+
+#include <array>
+#include <sys/types.h>
+
+#include "Helpers.hpp"
+#include "Process.hpp"
+
+namespace arch {
+class LinuxProcess : public Process {
+public:
+    LinuxProcess(pid_t process_id);
+    ~LinuxProcess() override = default;
+
+    uint32_t process_id() override;
+    bool ok() override;
+
+    std::optional<std::string> get_typename(uintptr_t ptr) override;
+    std::optional<std::string> get_typename_from_vtable(uintptr_t ptr) override;
+
+protected:
+    bool handle_write(uintptr_t address, const void* buffer, size_t size) override;
+    bool handle_read(uintptr_t address, void* buffer, size_t size) override;
+    std::optional<uint64_t> handle_protect(uintptr_t address, size_t size, uint64_t flags) override;
+    std::optional<uintptr_t> handle_allocate(uintptr_t address, size_t size, uint64_t flags) override;
+
+private:
+    pid_t m_process{};
+    int rw_handle;
+};
+
+class LinuxHelpers : public Helpers {
+public:
+    ~LinuxHelpers() override = default;
+
+    std::map<uint32_t, std::string> processes() override;
+};
+} // namespace arch

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -34,10 +34,15 @@ CPMAddPackage(
         DOWNLOAD_ONLY YES
 )
 if (nativefiledialog_ADDED)
+	if(MSVC)
+		set(NFD_IMPLEMENTATION ${nativefiledialog_SOURCE_DIR}/src/nfd_win.cpp)
+	else()
+		set(NFD_IMPLEMENTATION ${nativefiledialog_SOURCE_DIR}/src/nfd_zenity.c)
+    endif()
     add_library(
             nativefiledialog STATIC
             ${nativefiledialog_SOURCE_DIR}/src/nfd_common.c
-            ${nativefiledialog_SOURCE_DIR}/src/nfd_win.cpp
+            ${NFD_IMPLEMENTATION}
     )
     target_include_directories(nativefiledialog PUBLIC $<BUILD_INTERFACE:${nativefiledialog_SOURCE_DIR}>/src/include)
 endif ()
@@ -95,6 +100,7 @@ if (lua_ADDED)
 endif ()
 
 # sol2
+# TODO Merge this or upgrade to 3.5.0 when it comes out https://github.com/ThePhD/sol2/commit/d805d027e0a0a7222e936926139f06e23828ce9f
 CPMAddPackage("gh:ThePhD/sol2@3.3.0")
 
 # luagenny
@@ -112,7 +118,7 @@ if (luagenny_ADDED)
     if (MSVC)
         target_compile_options(luagenny PUBLIC /bigobj)
     else ()
-        target_compile_options(luagenny PRIVATE -fdeclspec -Wno-ignored-attributes)
+        target_compile_options(luagenny PRIVATE -Wno-ignored-attributes)
     endif ()
 endif ()
 
@@ -125,6 +131,6 @@ add_library(scope_guard INTERFACE)
 target_include_directories(scope_guard INTERFACE "scope_guard")
 
 # SDL_Trigger
-add_library(SDL_Trigger STATIC "SDL_Trigger/SDL_Trigger.cpp")
+add_library(SDL_Trigger STATIC "SDL_Trigger/sdl_trigger.cpp")
 target_include_directories(SDL_Trigger INTERFACE "SDL_Trigger")
 target_link_libraries(SDL_Trigger PUBLIC SDL3::SDL3)


### PR DESCRIPTION
This PR does multiple things:
- It makes the project build on Linux
- It adds support for reading and writing from Linux
- It fixes a few bugs in the architecture code
- It unimplements ppl.h for systems that don't have it.

Those changes all end up giving a basic Linux support for reading and writing.

Protection and Allocation are technically possible, although I haven't implemented them yet, because I feel like the API is kinda lacking here. Under Linux you need to be a debugger to do those things and there may only be one debugger attached to a process at once. And I feel like making regenny be a debugger would not only increase the complexity massively but also be a rough overstep in bounds, because I mostly have GDB attached to the processes that I would like to use regenny on and that would conflict. Perhaps laziness could help here, but that would add even more complexity. I have done it before and just getting those things is very hard because hijacking a thread **safely** is very complex.

I also think the Lua api is bad, "get_typename" and "get_typename_from_vtable" can be implemented from linux, 
get_typename (I assume from a class) is just dereferencing the first pointer to get the vtable and get_typename_from_vtable then just needs to subtract sizeof(void*) from the pointer, read that pointer, then add sizeof(void*) and read the const char* from that address. (RTTI information is stored behind the vtable with GCC, not sure how MSVC does it, haven't looked at it). But since the Process api forces me to provide a function (as it is virtual), the Lua API doesn't need to restrict it to windows. allocate_rwx and protect_rwx being Windows specific is dumb, both can be reimplemented by just calling allocate and protect with RWX permissions. So it should probably be moved to the process and be made virtual so that the implementations can just use their constants.

Apart from that, create_remote_thread is possible, I have in fact done it before, but it is even harder than doing allocation and protection and the amount of state and error handling is insane. I will never implement that. I think derives_from is possible, but I have never looked into GCC RTTI enough to know how.

This is basically it... I also feel like the read_only_allocations thing in the Process is bad, I tried doing something like that, but it just caused some people on low end PCs to run out of memory when using my libraries (speaking of which you can find on my profile, most of the LinuxProcess code just leeches off of my MemoryManager library), because if the process has many libraries then you just end up cloning all of them and that can easily take like a gigabyte... Laziness helps here.

Anyways, I might work more on this, but don't take anything for granted... I also have not tested if this breaks windows support, although I have tried to not break it, but I just have no windows systems running apart from VMs and I don't feel like fighting with Visual Studio, MSVC and Windows-CMake again.

EDIT: I just realized while reading through it one more time, that I may come off as a bit disrespectful, but I'm not, I'm just exhausted from life. I'm sorry.

EDIT2: GCC 15 is also not supported because https://github.com/ThePhD/sol2/issues/1695 is not fixed in a mainline release yet. (GCC 14 is what I tested it with and it appears to work)