### PR TITLE
Add MCP server

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,12 @@
+{
+  "mcpServers": {
+    "regenny": {
+      "type": "stdio",
+      "command": "dotnet",
+      "args": ["run", "--project", "mcp-server"],
+      "env": {
+        "REGENNY_API_URL": "http://localhost:12025"
+      }
+    }
+  }
+}

--- a/AGENT.md
+++ b/AGENT.md
@@ -1,0 +1,266 @@
+# ReGenny Agent Guide
+
+ReGenny is a reverse engineering GUI tool for interactively reconstructing memory structures in live Windows processes. It parses `.genny` files (C-like struct definitions), attaches to a target process, and renders live memory as typed structures.
+
+## Quick Start Workflow
+
+1. **Check status**: `regenny_status` -- see if a file is open and a process is attached
+2. **List processes**: `regenny_list_processes` -- find the target process
+3. **Attach**: `regenny_attach` with PID or process name
+4. **Open/create a .genny file**: `regenny_open_file` or `regenny_new_file`
+5. **List types**: `regenny_list_types` -- see what structs are defined
+6. **Select a type**: `regenny_select_type` with a name and address to view it in the UI
+7. **Read memory**: `regenny_read_memory` or `regenny_read_typed` for raw access
+8. **Modify definitions**: `regenny_set_file` to update the .genny content (triggers re-parse)
+9. **Use Lua**: `regenny_lua_eval` for complex operations using the full scripting API
+
+## The .genny File Format
+
+`.genny` files define types using a C-like syntax. They are parsed by ReGenny and used to overlay memory.
+
+### Primitive Types
+
+Primitives must be declared with a name, byte size, and optional metadata tag:
+
+```
+type bool 1 [[bool]]
+type byte 1 [[u8]]
+type ubyte 1 [[u8]]
+type char 1 [[utf8]]
+type wchar_t 2 [[utf16]]
+type short 2 [[i16]]
+type ushort 2 [[u16]]
+type int 4 [[i32]]
+type uint 4 [[u32]]
+type float 4 [[f32]]
+type double 8 [[f64]]
+type int64_t 8 [[i64]]
+type uint64_t 8 [[u64]]
+type uintptr_t 8 [[u64]]
+```
+
+Metadata tags control how values are displayed: `[[i32]]` = signed 32-bit int, `[[f32]]` = float, `[[utf8*]]` = null-terminated string pointer, etc.
+
+### Structs
+
+```
+struct MyStruct {
+    int field_a
+    float field_b
+    bool flag
+}
+```
+
+### Explicit Offsets
+
+Use `+N` to place a field at a specific byte offset:
+
+```
+struct Player {
+    int health +0x10
+    int max_health
+    float position_x +0x40
+    float position_y
+    float position_z
+}
+```
+
+Fields without `+N` are placed sequentially after the previous field.
+
+### Explicit Struct Size
+
+```
+struct PaddedStruct 0x100 {
+    int value
+}
+```
+
+This declares the struct as 0x100 bytes total, regardless of field layout.
+
+### Pointers
+
+```
+struct Node {
+    int value
+    Node* next
+    char* name [[utf8*]]
+}
+```
+
+### Arrays
+
+```
+struct Container {
+    int values[10]
+    float matrix[4][4]
+    Item* items
+}
+```
+
+### Enums
+
+```
+enum Direction {
+    NORTH = 0,
+    SOUTH = 1,
+    EAST = 2,
+    WEST = 3,
+}
+
+enum Color : byte {
+    RED = 1,
+    GREEN = 2,
+    BLUE = 3
+}
+```
+
+### Bitfields
+
+```
+struct Flags {
+    uint enabled : 1
+    uint mode : 3
+    uint level : 4
+}
+```
+
+### Inheritance
+
+```
+struct Base {
+    int base_field
+}
+
+struct Derived : Base {
+    int derived_field
+}
+
+struct MultiDerived : Base1, Base2 {
+    int own_field
+}
+```
+
+### Imports
+
+```
+import "types.genny"
+import "player.genny"
+```
+
+### Namespaces
+
+```
+namespace app {
+    struct Player {
+        int health
+    }
+}
+```
+
+Types in namespaces are referenced with dot notation: `app.Player`
+
+## Lua Scripting API
+
+ReGenny embeds Lua 5.4 with full access to the type system and process memory.
+
+### Key Globals
+
+- `regenny` -- the ReGenny app instance
+  - `regenny:type()` -- current selected type
+  - `regenny:address()` -- current address
+  - `regenny:overlay()` -- StructOverlay for current type at current address
+  - `regenny:sdk()` -- the parsed SDK (Sdk object)
+  - `regenny:process()` -- the attached Process
+
+- `sdkgenny` -- type system library
+  - `sdkgenny.StructOverlay(address, struct)` -- create an overlay
+  - `sdkgenny.PointerOverlay(address, pointer)` -- create a pointer overlay
+  - `sdkgenny.parse(code)` -- parse .genny source code string, returns Sdk
+  - `sdkgenny.parse_file(path)` -- parse a .genny file, returns Sdk
+
+### Process Memory Access
+
+```lua
+local proc = regenny:process()
+local val = proc:read_uint32(0x7FF6A000)
+proc:write_uint32(0x7FF6A000, 42)
+
+-- Available: read/write_uint8/16/32/64, read/write_int8/16/32/64
+-- read/write_float, read/write_double, read_string(addr, true)
+
+-- Module info
+for _, mod in ipairs(proc:modules()) do
+    print(mod.name, string.format("0x%X", mod.start), mod.size)
+end
+```
+
+### Struct Overlays (typed memory access)
+
+```lua
+local overlay = regenny:overlay()
+-- Access fields by name -- reads from process memory automatically
+print(overlay.health)
+print(overlay.position_x)
+-- Write back
+overlay.health = 100
+
+-- Pointer traversal
+local next_node = overlay.next:d()  -- dereference pointer
+print(next_node.value)
+
+-- Array indexing
+local first = overlay.items[0]
+```
+
+### Type System
+
+```lua
+local sdk = regenny:sdk()
+local ns = sdk:global_ns()
+
+-- Create types programmatically
+local my_struct = ns:struct("NewStruct")
+my_struct:size(0x50)
+local hp_var = my_struct:variable("health")
+hp_var:type("int")
+hp_var:offset(0x10)
+
+-- Generate C++ headers
+sdk:generate("output/path/")
+```
+
+## Common Patterns
+
+### Exploring Unknown Memory
+
+```lua
+-- Read a block and look for patterns
+local proc = regenny:process()
+local addr = 0x7FF6A000
+for i = 0, 0x100, 4 do
+    local val = proc:read_uint32(addr + i)
+    if val and val ~= 0 then
+        print(string.format("+0x%X: %d (0x%X)", i, val, val))
+    end
+end
+```
+
+### RTTI Discovery (Windows)
+
+Use `regenny_rtti_typename` to identify C++ class types at runtime via their vtable pointers.
+
+### Iterative Type Reconstruction
+
+1. Start with a minimal struct: `struct Unknown 0x100 { int field_0 }`
+2. Use `regenny_read_memory` to see raw bytes at the address
+3. Identify patterns (floats at +0x10, pointer at +0x20, etc.)
+4. Update the .genny file with `regenny_set_file`
+5. Use `regenny_select_type` to view the updated layout live
+
+## Gotchas
+
+- Addresses must be valid in the target process. Reading invalid addresses returns null/errors.
+- `.genny` files auto-reload when modified on disk (1-second poll). `regenny_set_file` also triggers immediate re-parse.
+- The Lua state persists between eval calls. Variables set in one call are available in the next.
+- `regenny_lua_eval` tries to evaluate as an expression first (prefixes `return`), then falls back to statement execution.
+- Process attachment, file opening, and type selection are deferred to the main UI thread. They execute on the next frame after the API call returns.

--- a/AGENT.md
+++ b/AGENT.md
@@ -2,6 +2,8 @@
 
 ReGenny is a reverse engineering GUI tool for interactively reconstructing memory structures in live Windows processes. It parses `.genny` files (C-like struct definitions), attaches to a target process, and renders live memory as typed structures.
 
+Full scripting reference: https://praydog.github.io/regenny-book/
+
 ## Quick Start Workflow
 
 1. **Check status**: `regenny_status` -- see if a file is open and a process is attached
@@ -13,6 +15,14 @@ ReGenny is a reverse engineering GUI tool for interactively reconstructing memor
 7. **Read memory**: `regenny_read_memory` or `regenny_read_typed` for raw access
 8. **Modify definitions**: `regenny_set_file` to update the .genny content (triggers re-parse)
 9. **Use Lua**: `regenny_lua_eval` for complex operations using the full scripting API
+
+## Address Syntax
+
+The address field (and `regenny_select_type` address parameter) supports:
+
+- **Absolute hex**: `0x7FF6A000`
+- **Module-relative**: `game.exe+0x5000` (partial module name OK, e.g. `client.dll+0x1234`)
+- **Pointer dereference chains**: `game.exe+0x5000->0x24->0x8` (follows pointers at each `->` offset)
 
 ## The .genny File Format
 
@@ -39,7 +49,7 @@ type uint64_t 8 [[u64]]
 type uintptr_t 8 [[u64]]
 ```
 
-Metadata tags control how values are displayed: `[[i32]]` = signed 32-bit int, `[[f32]]` = float, `[[utf8*]]` = null-terminated string pointer, etc.
+Metadata tags control how values are displayed: `[[i32]]` = signed 32-bit int, `[[f32]]` = float, `[[utf8*]]` = null-terminated string pointer, etc. Metadata can also be applied per-variable inline: `char* name [[utf8*]]`.
 
 ### Structs
 
@@ -50,6 +60,8 @@ struct MyStruct {
     bool flag
 }
 ```
+
+`class` is also supported (identical semantics to `struct` in .genny).
 
 ### Explicit Offsets
 
@@ -157,7 +169,7 @@ namespace app {
 }
 ```
 
-Types in namespaces are referenced with dot notation: `app.Player`
+Types in namespaces are referenced with dot notation: `app.Player`. Namespaces can be nested. Structs, enums, and classes can be nested within other structs/classes.
 
 ## Lua Scripting API
 
@@ -166,8 +178,8 @@ ReGenny embeds Lua 5.4 with full access to the type system and process memory.
 ### Key Globals
 
 - `regenny` -- the ReGenny app instance
-  - `regenny:type()` -- current selected type
-  - `regenny:address()` -- current address
+  - `regenny:type()` -- current selected type (sdkgenny.Type; use `:as_struct()` to get Struct methods)
+  - `regenny:address()` -- current address (uintptr_t)
   - `regenny:overlay()` -- StructOverlay for current type at current address
   - `regenny:sdk()` -- the parsed SDK (Sdk object)
   - `regenny:process()` -- the attached Process
@@ -185,31 +197,77 @@ local proc = regenny:process()
 local val = proc:read_uint32(0x7FF6A000)
 proc:write_uint32(0x7FF6A000, 42)
 
--- Available: read/write_uint8/16/32/64, read/write_int8/16/32/64
--- read/write_float, read/write_double, read_string(addr, true)
+-- All read/write methods:
+-- proc:read_uint8/16/32/64(addr)     proc:write_uint8/16/32/64(addr, val)
+-- proc:read_int8/16/32/64(addr)      proc:write_int8/16/32/64(addr, val)
+-- proc:read_float(addr)              proc:write_float(addr, val)
+-- proc:read_double(addr)             proc:write_double(addr, val)
+-- proc:read_string(addr, do_strlen)  -- do_strlen=true for null-terminated
 
--- Module info
+-- Module lookup
+local mod = proc:get_module("client.dll")  -- by name
+print(mod.name, mod.start, mod.end, mod.size)
+
+local mod2 = proc:get_module_within(some_addr)  -- find module containing address
+
 for _, mod in ipairs(proc:modules()) do
     print(mod.name, string.format("0x%X", mod.start), mod.size)
 end
+
+-- Memory regions
+for _, alloc in ipairs(proc:allocations()) do
+    -- alloc.start, alloc.end, alloc.size, alloc.read, alloc.write, alloc.execute
+end
+
+-- Memory management
+proc:protect(addr, size, flags)         -- VirtualProtectEx; returns old flags
+proc:allocate(addr, size, flags)        -- VirtualAllocEx; addr=0 lets OS choose
+```
+
+### WindowsProcess Extensions
+
+When attached to a Windows process, the process object has additional methods:
+
+```lua
+local proc = regenny:process()  -- actually a WindowsProcess on Windows
+
+-- RTTI
+local name = proc:get_typename(ptr_addr)               -- RTTI class name from object pointer
+local name = proc:get_typename_from_vtable(vtable_addr) -- RTTI class name from vtable pointer
+
+-- Code injection
+proc:allocate_rwx(addr, size)       -- allocate PAGE_EXECUTE_READWRITE
+proc:protect_rwx(addr, size)        -- change to PAGE_EXECUTE_READWRITE
+proc:create_remote_thread(addr, param)  -- run thread in target process
 ```
 
 ### Struct Overlays (typed memory access)
 
 ```lua
 local overlay = regenny:overlay()
+
 -- Access fields by name -- reads from process memory automatically
 print(overlay.health)
 print(overlay.position_x)
+
 -- Write back
 overlay.health = 100
 
 -- Pointer traversal
-local next_node = overlay.next:d()  -- dereference pointer
+local next_node = overlay.next:d()  -- dereference pointer (:deref() and :dereference() are aliases)
 print(next_node.value)
+print(overlay.next:ptr())           -- raw destination address (uintptr_t)
+print(overlay.next:address())       -- address of the pointer variable itself
 
--- Array indexing
-local first = overlay.items[0]
+-- Array indexing (treats struct as inline array: addr + N * struct_size)
+local second = overlay[1]
+
+-- Overlay introspection
+print(overlay:address())   -- base memory address
+print(overlay:type():name()) -- the sdkgenny.Struct name
+
+-- Writing raw pointer values
+overlay.some_ptr = other_overlay:address()
 ```
 
 ### Type System
@@ -224,6 +282,33 @@ my_struct:size(0x50)
 local hp_var = my_struct:variable("health")
 hp_var:type("int")
 hp_var:offset(0x10)
+
+-- Type introspection (Object base methods, available on all types)
+local s = regenny:type():as_struct()  -- cast Type to Struct
+print(s:name())
+print(s:size())
+for _, var in ipairs(s:get_all_variable()) do
+    print(var:name(), var:offset(), var:type():name())
+end
+
+-- Parent traversal
+for _, parent in ipairs(s:parents()) do
+    print("inherits:", parent:name())
+end
+
+-- Type checking and casting
+if obj:is_struct() then
+    local s = obj:as_struct()
+end
+-- Also: is_enum(), as_enum(), is_pointer(), as_pointer(), etc.
+-- find_struct(name), find_variable(name), find_in_parents("variable", name)
+
+-- Variable details
+local v = s:get_all_variable()[1]
+print(v:offset(), v:end())  -- byte range
+print(v:is_bitfield(), v:bit_offset(), v:bit_size())
+v:append()      -- auto-place after previous variable
+v:bit_append()  -- auto-place as next bitfield in same storage unit
 
 -- Generate C++ headers
 sdk:generate("output/path/")
@@ -245,9 +330,27 @@ for i = 0, 0x100, 4 do
 end
 ```
 
+### Finding Pointers and Strings
+
+```lua
+local proc = regenny:process()
+local addr = 0x7FF6A000
+for i = 0, 0x100, 8 do
+    local ptr = proc:read_uint64(addr + i)
+    if ptr and ptr > 0x10000000000 and ptr < 0x7FFFFFFFFFFF then
+        local str = proc:read_string(ptr, true)
+        if #str > 0 and #str < 100 then
+            print(string.format("+0x%X: 0x%X -> \"%s\"", i, ptr, str))
+        else
+            print(string.format("+0x%X: 0x%X (ptr)", i, ptr))
+        end
+    end
+end
+```
+
 ### RTTI Discovery (Windows)
 
-Use `regenny_rtti_typename` to identify C++ class types at runtime via their vtable pointers.
+Use `regenny_rtti_typename` to identify C++ class types at runtime via their vtable pointers. In Lua: `proc:get_typename(object_addr)` or `proc:get_typename_from_vtable(vtable_addr)`.
 
 ### Iterative Type Reconstruction
 
@@ -257,6 +360,23 @@ Use `regenny_rtti_typename` to identify C++ class types at runtime via their vta
 4. Update the .genny file with `regenny_set_file`
 5. Use `regenny_select_type` to view the updated layout live
 
+### Traversing Pointer Arrays
+
+```lua
+local proc = regenny:process()
+local overlay = regenny:overlay()
+
+-- If a struct has a pointer to an array of structs:
+local array_ptr = proc:read_uint64(overlay:address() + 0x48)
+local count = proc:read_uint32(overlay:address() + 0x40)
+for i = 0, count - 1 do
+    local entry_ptr = proc:read_uint64(array_ptr + i * 8)  -- array of pointers
+    local name_ptr = proc:read_uint64(entry_ptr)             -- first field is a char*
+    local name = proc:read_string(name_ptr, true)
+    print(string.format("[%d] %s", i, name))
+end
+```
+
 ## Gotchas
 
 - Addresses must be valid in the target process. Reading invalid addresses returns null/errors.
@@ -264,3 +384,6 @@ Use `regenny_rtti_typename` to identify C++ class types at runtime via their vta
 - The Lua state persists between eval calls. Variables set in one call are available in the next.
 - `regenny_lua_eval` tries to evaluate as an expression first (prefixes `return`), then falls back to statement execution.
 - Process attachment, file opening, and type selection are deferred to the main UI thread. They execute on the next frame after the API call returns.
+- `regenny:type()` returns a base `Type`. To access struct-specific methods (size, parents, variables), cast with `:as_struct()`.
+- Lua 5.4 has strict integer/float distinction. Large `u64` values may overflow Lua integers. Use `string.format("0x%X", val)` for display.
+- `proc:read_*` methods return `nil` on failure (invalid address, unreadable memory). Always nil-check in loops.

--- a/AGENT.md
+++ b/AGENT.md
@@ -385,5 +385,5 @@ end
 - `regenny_lua_eval` tries to evaluate as an expression first (prefixes `return`), then falls back to statement execution.
 - Process attachment, file opening, and type selection are deferred to the main UI thread. They execute on the next frame after the API call returns.
 - `regenny:type()` returns a base `Type`. To access struct-specific methods (size, parents, variables), cast with `:as_struct()`.
-- Lua 5.4 has strict integer/float distinction. Large `u64` values may overflow Lua integers. Use `string.format("0x%X", val)` for display.
+- Lua 5.4 has strict integer/float distinction. `string.format("%X", val)` **fails** on large u64 values (e.g. pointers with high bits set). Workaround: read as two u32s and format separately: `string.format("%08X%08X", hi, lo)`. Or use `proc:read_uint32()` for the high and low halves.
 - `proc:read_*` methods return `nil` on failure (invalid address, unreadable memory). Always nil-check in loops.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,4 +27,5 @@ target_link_libraries(regenny PRIVATE
         lua
         sol2::sol2
         luagenny
+        httplib
 )

--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ cmake -B build
 cmake --build build
 ```
 
+## MCP Integration
+
+ReGenny exposes an HTTP API on `localhost:12025` for tool integration. An MCP server is included in `mcp-server/` for AI-assisted reverse engineering. See `AGENT.md` for the agent navigation guide.
+
 ## Design decisions
 
 * ReGenny uses plaintext project files instead of binary ones (`.genny` and `.json`). Plaintext formats are much better for inclusion in git repositories and makes collaborating with others on ReGenny projects easier since you can diff/merge project files.

--- a/mcp-server/Http.cs
+++ b/mcp-server/Http.cs
@@ -18,14 +18,15 @@ static class Http
                 .Select(kv => $"{Uri.EscapeDataString(kv.Key)}={Uri.EscapeDataString(kv.Value!)}"));
             if (qs.Length > 0) url += "?" + qs;
         }
-        return await Client.GetStringAsync(url);
+        using var res = await Client.GetAsync(url);
+        return await res.Content.ReadAsStringAsync();
     }
 
     public static async Task<string> Post(string path, object body)
     {
         var json = JsonSerializer.Serialize(body);
         var content = new StringContent(json, Encoding.UTF8, "application/json");
-        var res = await Client.PostAsync(Base + path, content);
+        using var res = await Client.PostAsync(Base + path, content);
         return await res.Content.ReadAsStringAsync();
     }
 }

--- a/mcp-server/Http.cs
+++ b/mcp-server/Http.cs
@@ -1,0 +1,31 @@
+using System.Text;
+using System.Text.Json;
+
+namespace ReGennyMcp;
+
+static class Http
+{
+    static readonly string Base = Environment.GetEnvironmentVariable("REGENNY_API_URL") ?? "http://localhost:12025";
+    static readonly HttpClient Client = new();
+
+    public static async Task<string> Get(string path, Dictionary<string, string?>? query = null)
+    {
+        var url = Base + path;
+        if (query is { Count: > 0 })
+        {
+            var qs = string.Join("&", query
+                .Where(kv => kv.Value is not null)
+                .Select(kv => $"{Uri.EscapeDataString(kv.Key)}={Uri.EscapeDataString(kv.Value!)}"));
+            if (qs.Length > 0) url += "?" + qs;
+        }
+        return await Client.GetStringAsync(url);
+    }
+
+    public static async Task<string> Post(string path, object body)
+    {
+        var json = JsonSerializer.Serialize(body);
+        var content = new StringContent(json, Encoding.UTF8, "application/json");
+        var res = await Client.PostAsync(Base + path, content);
+        return await res.Content.ReadAsStringAsync();
+    }
+}

--- a/mcp-server/McpServer.csproj
+++ b/mcp-server/McpServer.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="ModelContextProtocol" Version="*-*" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="*" />
+  </ItemGroup>
+</Project>

--- a/mcp-server/McpServer.csproj
+++ b/mcp-server/McpServer.csproj
@@ -6,7 +6,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="ModelContextProtocol" Version="*-*" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="*" />
+    <PackageReference Include="ModelContextProtocol" Version="1.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.5" />
   </ItemGroup>
 </Project>

--- a/mcp-server/Program.cs
+++ b/mcp-server/Program.cs
@@ -1,0 +1,13 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using ModelContextProtocol;
+
+var builder = Host.CreateApplicationBuilder(args);
+builder.Logging.ClearProviders();
+builder.Logging.AddDebug();
+builder.Services
+    .AddMcpServer()
+    .WithStdioServerTransport()
+    .WithToolsFromAssembly();
+await builder.Build().RunAsync();

--- a/mcp-server/Tools.cs
+++ b/mcp-server/Tools.cs
@@ -1,0 +1,223 @@
+using System.ComponentModel;
+using System.Text.Json;
+using ModelContextProtocol.Server;
+
+namespace ReGennyMcp;
+
+// ── Status & Connection ──────────────────────────────────────────────
+
+[McpServerToolType]
+public static class StatusTools
+{
+    [McpServerTool(Name = "regenny_status")]
+    [Description("Get ReGenny app state: attached process name/PID, current type, current address, whether an SDK is loaded")]
+    public static async Task<string> Status()
+        => await Http.Get("/api/status");
+
+    [McpServerTool(Name = "regenny_list_processes")]
+    [Description("List available processes to attach to. Returns array of {pid, name}.")]
+    public static async Task<string> ListProcesses()
+        => await Http.Get("/api/processes");
+
+    [McpServerTool(Name = "regenny_attach")]
+    [Description("Attach to a target process by PID or name. Deferred to main thread.")]
+    public static async Task<string> Attach(
+        [Description("Process ID (integer)")] int? pid = null,
+        [Description("Process name (e.g. 'game.exe')")] string? name = null)
+        => await Http.Post("/api/attach", new { pid, name });
+
+    [McpServerTool(Name = "regenny_detach")]
+    [Description("Detach from the current process")]
+    public static async Task<string> Detach()
+        => await Http.Post("/api/detach", new { });
+
+    [McpServerTool(Name = "regenny_help")]
+    [Description("Get the agent navigation guide for ReGenny. Covers: .genny file format, Lua API, typical workflows, type system. **Call this FIRST in a new session.**")]
+    public static async Task<string> Help()
+    {
+        try { return await Http.Get("/api/help"); }
+        catch { /* ReGenny not running — fall through to local file */ }
+
+        var agentMdPath = ResolveAgentMd();
+        if (agentMdPath is not null && File.Exists(agentMdPath))
+            return await File.ReadAllTextAsync(agentMdPath);
+
+        return """{"error": "AGENT.md not found. Ensure ReGenny is running, or the MCP server is run from the regenny repo root."}""";
+    }
+
+    static string? ResolveAgentMd()
+    {
+        var dir = Path.GetDirectoryName(typeof(StatusTools).Assembly.Location);
+        while (dir is not null)
+        {
+            var candidate = Path.Combine(dir, "AGENT.md");
+            if (File.Exists(candidate)) return candidate;
+            dir = Path.GetDirectoryName(dir);
+        }
+        return null;
+    }
+}
+
+// ── Memory ───────────────────────────────────────────────────────────
+
+[McpServerToolType]
+public static class MemoryTools
+{
+    [McpServerTool(Name = "regenny_read_memory")]
+    [Description("Read N bytes at address as hex dump with ASCII sidebar. Requires attached process.")]
+    public static async Task<string> ReadMemory(
+        [Description("Memory address (hex e.g. '0x7FF6A000' or decimal)")] string address,
+        [Description("Number of bytes to read (max 8192)")] int size = 256)
+        => await Http.Get("/api/memory/read", new() { ["address"] = address, ["size"] = size.ToString() });
+
+    [McpServerTool(Name = "regenny_read_typed")]
+    [Description("Read typed values at address. Types: u8,i8,u16,i16,u32,i32,u64,i64,f32,f64,ptr. Use count>1 to read sequential values.")]
+    public static async Task<string> ReadTyped(
+        [Description("Memory address (hex or decimal)")] string address,
+        [Description("Value type: u8,i8,u16,i16,u32,i32,u64,i64,f32,f64,ptr")] string type,
+        [Description("Number of sequential values to read (default 1, max 50)")] int? count = null)
+        => await Http.Get("/api/memory/read_typed", new() {
+            ["address"] = address, ["type"] = type, ["count"] = count?.ToString()
+        });
+
+    [McpServerTool(Name = "regenny_write_memory")]
+    [Description("Write a typed value at address. Types: u8,i8,u16,i16,u32,i32,u64,i64,f32,f64")]
+    public static async Task<string> WriteMemory(
+        [Description("Memory address (hex or decimal)")] string address,
+        [Description("Value type: u8,i8,u16,i16,u32,i32,u64,i64,f32,f64")] string type,
+        [Description("Value to write (JSON number)")] JsonElement value)
+        => await Http.Post("/api/memory/write", new { address, type, value });
+
+    [McpServerTool(Name = "regenny_read_string")]
+    [Description("Read a null-terminated string at address")]
+    public static async Task<string> ReadString(
+        [Description("Memory address (hex or decimal)")] string address,
+        [Description("Maximum string length (default 256, max 4096)")] int? max_length = null)
+        => await Http.Get("/api/memory/read_string", new() {
+            ["address"] = address, ["max_length"] = max_length?.ToString()
+        });
+
+    [McpServerTool(Name = "regenny_list_modules")]
+    [Description("List loaded modules in the attached process: name, start address, end address, size")]
+    public static async Task<string> ListModules()
+        => await Http.Get("/api/modules");
+}
+
+// ── Genny Files ──────────────────────────────────────────────────────
+
+[McpServerToolType]
+public static class GennyTools
+{
+    [McpServerTool(Name = "regenny_get_file")]
+    [Description("Get the current .genny file content and path")]
+    public static async Task<string> GetFile()
+        => await Http.Get("/api/genny/content");
+
+    [McpServerTool(Name = "regenny_set_file")]
+    [Description("Write new content to the current .genny file. Triggers re-parse and UI update. Use this to modify struct definitions.")]
+    public static async Task<string> SetFile(
+        [Description("New .genny file content (full file text)")] string content)
+        => await Http.Post("/api/genny/content", new { content });
+
+    [McpServerTool(Name = "regenny_open_file")]
+    [Description("Open a .genny file by path in ReGenny")]
+    public static async Task<string> OpenFile(
+        [Description("Absolute or relative path to a .genny file")] string path)
+        => await Http.Post("/api/genny/open", new { path });
+
+    [McpServerTool(Name = "regenny_new_file")]
+    [Description("Create a new .genny file at the given path with initial content, and open it in ReGenny")]
+    public static async Task<string> NewFile(
+        [Description("Path for the new .genny file")] string path,
+        [Description("Initial .genny content (optional — default template provided if empty)")] string? content = null)
+        => await Http.Post("/api/genny/new", new { path, content });
+
+    [McpServerTool(Name = "regenny_reload")]
+    [Description("Force re-parse the current .genny file (useful after external edits)")]
+    public static async Task<string> Reload()
+        => await Http.Post("/api/genny/reload", new { });
+}
+
+// ── Type Introspection ───────────────────────────────────────────────
+
+[McpServerToolType]
+public static class TypeTools
+{
+    [McpServerTool(Name = "regenny_list_types")]
+    [Description("List all struct/class type names from the parsed .genny SDK, with their sizes")]
+    public static async Task<string> ListTypes()
+        => await Http.Get("/api/types");
+
+    [McpServerTool(Name = "regenny_get_type")]
+    [Description("Get full struct layout: fields with offsets, sizes, types, parent classes, metadata. Use dot-separated names for namespaced types.")]
+    public static async Task<string> GetType(
+        [Description("Type name (e.g. 'MyStruct' or 'Namespace.MyStruct')")] string name)
+        => await Http.Get("/api/type", new() { ["name"] = name });
+
+    [McpServerTool(Name = "regenny_select_type")]
+    [Description("Set the active type and address in the ReGenny UI. This controls what is displayed in the Memory View.")]
+    public static async Task<string> SelectType(
+        [Description("Type name to display")] string name,
+        [Description("Memory address to view the type at (hex or decimal)")] string? address = null)
+        => await Http.Post("/api/type/select", new { name, address });
+}
+
+// ── Lua Scripting ────────────────────────────────────────────────────
+
+[McpServerToolType]
+public static class LuaTools
+{
+    [McpServerTool(Name = "regenny_lua_eval")]
+    [Description("Execute Lua code in ReGenny's embedded Lua state. Returns stdout output and expression result. Has access to: regenny (app), sdkgenny (type system), process read/write. Expressions are auto-returned; statements execute normally.")]
+    public static async Task<string> LuaEval(
+        [Description("Lua code to execute")] string code)
+        => await Http.Post("/api/lua/eval", new { code });
+
+    [McpServerTool(Name = "regenny_lua_exec_file")]
+    [Description("Execute a .lua script file by path in ReGenny's Lua state")]
+    public static async Task<string> LuaExecFile(
+        [Description("Path to the .lua file")] string path)
+        => await Http.Post("/api/lua/exec_file", new { path });
+
+    [McpServerTool(Name = "regenny_lua_write_script")]
+    [Description("Write a Lua script file to disk (creates directories as needed)")]
+    public static async Task<string> LuaWriteScript(
+        [Description("File path for the script")] string path,
+        [Description("Lua script content")] string content)
+        => await Http.Post("/api/lua/script", new { path, content });
+
+    [McpServerTool(Name = "regenny_lua_read_script")]
+    [Description("Read a Lua script file from disk")]
+    public static async Task<string> LuaReadScript(
+        [Description("Path to the .lua file")] string path)
+        => await Http.Get("/api/lua/script", new() { ["path"] = path });
+}
+
+// ── Project ──────────────────────────────────────────────────────────
+
+[McpServerToolType]
+public static class ProjectTools
+{
+    [McpServerTool(Name = "regenny_get_project")]
+    [Description("Get current project state: process info, type addresses, tabs, chosen type")]
+    public static async Task<string> GetProject()
+        => await Http.Get("/api/project");
+}
+
+// ── RTTI ─────────────────────────────────────────────────────────────
+
+[McpServerToolType]
+public static class RttiTools
+{
+    [McpServerTool(Name = "regenny_rtti_typename")]
+    [Description("Get RTTI type name at a pointer address (Windows only). The pointer should point to an object with a vtable.")]
+    public static async Task<string> RttiTypename(
+        [Description("Object pointer address (hex or decimal)")] string address)
+        => await Http.Get("/api/rtti/typename", new() { ["address"] = address });
+
+    [McpServerTool(Name = "regenny_rtti_vtable_typename")]
+    [Description("Get RTTI type name from a vtable pointer address (Windows only)")]
+    public static async Task<string> RttiVtableTypename(
+        [Description("Vtable pointer address (hex or decimal)")] string address)
+        => await Http.Get("/api/rtti/vtable_typename", new() { ["address"] = address });
+}

--- a/src/Api.cpp
+++ b/src/Api.cpp
@@ -1,0 +1,923 @@
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <mutex>
+
+#include <fmt/format.h>
+#include <httplib.h>
+#include <nlohmann/json.hpp>
+#include <sdkgenny.hpp>
+#include <spdlog/spdlog.h>
+
+#include "Api.hpp"
+#include "ReGenny.hpp"
+#include "arch/Arch.hpp"
+
+#ifdef _WIN32
+#include "arch/Windows.hpp"
+#endif
+
+using json = nlohmann::json;
+
+// ---------------------------------------------------------------------------
+// Lua output capture sink — captures spdlog output during Lua eval.
+// Installed temporarily around each eval call while m_lua_lock is held,
+// so there's no concurrency issue with the shared capture buffer.
+// ---------------------------------------------------------------------------
+#include <spdlog/sinks/base_sink.h>
+
+template <typename Mutex>
+class CaptureSink : public spdlog::sinks::base_sink<Mutex> {
+public:
+    std::string& buffer() { return m_buf; }
+    void clear() { m_buf.clear(); }
+
+protected:
+    void sink_it_(const spdlog::details::log_msg& msg) override {
+        spdlog::memory_buf_t formatted{};
+        spdlog::sinks::base_sink<Mutex>::formatter_->format(msg, formatted);
+        m_buf += fmt::to_string(formatted);
+    }
+    void flush_() override {}
+
+private:
+    std::string m_buf;
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+static json error_json(const std::string& msg) {
+    return json{{"error", msg}};
+}
+
+static void json_response(httplib::Response& res, const json& j) {
+    res.set_content(j.dump(), "application/json");
+}
+
+static void json_error(httplib::Response& res, const std::string& msg, int status = 400) {
+    res.status = status;
+    json_response(res, error_json(msg));
+}
+
+// Parse "0x..." or decimal address string to uintptr_t.
+static std::optional<uintptr_t> parse_addr_param(const std::string& s) {
+    try {
+        size_t pos{};
+        auto val = std::stoull(s, &pos, 0);
+        if (pos == s.size()) return static_cast<uintptr_t>(val);
+    } catch (...) {}
+    return std::nullopt;
+}
+
+// Recursively serialize a sdkgenny::Struct to JSON (fields, offsets, types, parents).
+static json serialize_struct(sdkgenny::Struct* s) {
+    json j;
+    j["name"] = s->name();
+    j["size"] = s->size();
+
+    // Parents
+    auto parents = json::array();
+    for (auto* parent : s->parents()) {
+        parents.push_back(parent->name());
+    }
+    j["parents"] = parents;
+
+    // Variables (fields)
+    auto fields = json::array();
+    std::function<void(sdkgenny::Struct*, uintptr_t)> add_vars = [&](sdkgenny::Struct* st, uintptr_t base_offset) {
+        for (auto* parent : st->parents()) {
+            add_vars(parent, base_offset);
+            base_offset += parent->size();
+        }
+        for (auto* var : st->get_all<sdkgenny::Variable>()) {
+            json f;
+            f["name"] = var->name();
+            f["offset"] = base_offset + var->offset();
+            if (var->type()) {
+                f["type"] = var->type()->name();
+                f["type_size"] = var->type()->size();
+
+                if (var->type()->is_a<sdkgenny::Pointer>()) {
+                    f["is_pointer"] = true;
+                    auto* ref = dynamic_cast<sdkgenny::Reference*>(var->type());
+                    if (ref && ref->to()) {
+                        f["points_to"] = ref->to()->name();
+                    }
+                } else if (var->type()->is_a<sdkgenny::Array>()) {
+                    f["is_array"] = true;
+                    auto* arr = dynamic_cast<sdkgenny::Array*>(var->type());
+                    if (arr) {
+                        f["array_count"] = arr->count();
+                        if (arr->of()) f["array_element_type"] = arr->of()->name();
+                    }
+                } else if (var->type()->is_a<sdkgenny::Struct>()) {
+                    f["is_struct"] = true;
+                } else if (var->type()->is_a<sdkgenny::Enum>()) {
+                    f["is_enum"] = true;
+                }
+            }
+            if (var->is_bitfield()) {
+                f["is_bitfield"] = true;
+                f["bit_offset"] = var->bit_offset();
+                f["bit_size"] = var->bit_size();
+            }
+
+            // Metadata (vector<string>)
+            auto& meta = var->metadata();
+            if (!meta.empty()) {
+                f["metadata"] = meta;
+            }
+
+            fields.push_back(f);
+        }
+    };
+    add_vars(s, 0);
+    j["fields"] = fields;
+
+    return j;
+}
+
+// ---------------------------------------------------------------------------
+// Api
+// ---------------------------------------------------------------------------
+
+Api::Api(ReGenny* regenny, int port)
+    : m_regenny{regenny}, m_server{std::make_unique<httplib::Server>()} {
+
+    // Determine port: env var > explicit arg > default 12025
+    if (auto* env = std::getenv("REGENNY_API_PORT"); env != nullptr) {
+        try { m_port = std::stoi(env); } catch (...) { m_port = 12025; }
+    } else if (port > 0) {
+        m_port = port;
+    } else {
+        m_port = 12025;
+    }
+
+    register_routes();
+
+    m_thread = std::thread(&Api::server_thread_fn, this);
+}
+
+Api::~Api() {
+    if (m_server) {
+        m_server->stop();
+    }
+    if (m_thread.joinable()) {
+        m_thread.join();
+    }
+}
+
+std::optional<Api::DeferredAttach> Api::consume_deferred_attach() {
+    std::scoped_lock lk{m_deferred_lock};
+    auto result = std::move(m_deferred_attach);
+    m_deferred_attach.reset();
+    return result;
+}
+
+std::optional<Api::DeferredOpen> Api::consume_deferred_open() {
+    std::scoped_lock lk{m_deferred_lock};
+    auto result = std::move(m_deferred_open);
+    m_deferred_open.reset();
+    return result;
+}
+
+std::optional<Api::DeferredTypeSelect> Api::consume_deferred_type_select() {
+    std::scoped_lock lk{m_deferred_lock};
+    auto result = std::move(m_deferred_type_select);
+    m_deferred_type_select.reset();
+    return result;
+}
+
+void Api::server_thread_fn() {
+    spdlog::info("[API] Starting HTTP server on port {}...", m_port);
+    if (!m_server->listen("127.0.0.1", m_port)) {
+        spdlog::error("[API] Failed to start HTTP server on port {}", m_port);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Route registration
+// ---------------------------------------------------------------------------
+
+void Api::register_routes() {
+    auto* rg = m_regenny;
+
+    // ── Status ───────────────────────────────────────────────────────────
+    m_server->Get("/api/status", [rg](const httplib::Request&, httplib::Response& res) {
+        json j;
+        auto& proc = rg->process();
+        j["attached"] = proc && proc->process_id() != 0;
+        j["process_id"] = proc ? proc->process_id() : 0;
+        // Access project fields via the accessors we have
+        if (rg->type()) {
+            j["current_type"] = rg->type()->name();
+        } else {
+            j["current_type"] = nullptr;
+        }
+        j["current_address"] = fmt::format("0x{:X}", rg->address());
+        j["sdk_loaded"] = rg->sdk() != nullptr;
+        json_response(res, j);
+    });
+
+    // ── Process Management ───────────────────────────────────────────────
+    m_server->Get("/api/processes", [rg](const httplib::Request&, httplib::Response& res) {
+        // We need helpers to list processes, but that's private.
+        // Use arch::make_helpers() directly.
+        auto helpers = arch::make_helpers();
+        auto procs = helpers->processes();
+        auto arr = json::array();
+        for (auto& [pid, name] : procs) {
+            arr.push_back(json{{"pid", pid}, {"name", name}});
+        }
+        json_response(res, arr);
+    });
+
+    m_server->Post("/api/attach", [this](const httplib::Request& req, httplib::Response& res) {
+        try {
+            auto body = json::parse(req.body);
+            DeferredAttach da;
+            if (body.contains("pid")) da.pid = body["pid"].get<uint32_t>();
+            if (body.contains("name")) da.name = body["name"].get<std::string>();
+
+            if (da.pid == 0 && !da.name.empty()) {
+                // Resolve name to PID
+                auto helpers = arch::make_helpers();
+                auto procs = helpers->processes();
+                for (auto& [pid, name] : procs) {
+                    if (name == da.name) {
+                        da.pid = pid;
+                        break;
+                    }
+                }
+            }
+
+            if (da.pid == 0) {
+                json_error(res, "Could not resolve process. Provide 'pid' or a valid 'name'.");
+                return;
+            }
+
+            // Fill in name if we only had PID
+            if (da.name.empty()) {
+                auto helpers = arch::make_helpers();
+                auto procs = helpers->processes();
+                if (procs.count(da.pid)) da.name = procs[da.pid];
+            }
+
+            {
+                std::scoped_lock lk{m_deferred_lock};
+                m_deferred_attach = da;
+            }
+            json_response(res, json{{"status", "ok"}, {"pid", da.pid}, {"name", da.name}});
+        } catch (const std::exception& e) {
+            json_error(res, e.what());
+        }
+    });
+
+    m_server->Post("/api/detach", [this](const httplib::Request&, httplib::Response& res) {
+        m_detach_requested.store(true);
+        json_response(res, json{{"status", "ok"}});
+    });
+
+    // ── Memory Operations ────────────────────────────────────────────────
+    m_server->Get("/api/memory/read", [rg](const httplib::Request& req, httplib::Response& res) {
+        auto& proc = rg->process();
+        if (!proc || proc->process_id() == 0) {
+            json_error(res, "Not attached to a process");
+            return;
+        }
+
+        auto addr_str = req.get_param_value("address");
+        auto size_str = req.get_param_value("size");
+        if (addr_str.empty() || size_str.empty()) {
+            json_error(res, "Required params: address, size");
+            return;
+        }
+
+        auto addr = parse_addr_param(addr_str);
+        if (!addr) { json_error(res, "Invalid address"); return; }
+
+        auto size = std::min(static_cast<size_t>(std::stoull(size_str, nullptr, 0)), size_t{8192});
+        std::vector<uint8_t> buf(size);
+
+        if (!proc->read(*addr, buf.data(), size)) {
+            json_error(res, "Read failed");
+            return;
+        }
+
+        // Format as hex dump with ASCII sidebar
+        std::string hex_dump;
+        for (size_t i = 0; i < size; i += 16) {
+            hex_dump += fmt::format("{:016X}  ", *addr + i);
+            std::string ascii;
+            for (size_t j = 0; j < 16 && i + j < size; j++) {
+                hex_dump += fmt::format("{:02X} ", buf[i + j]);
+                ascii += (buf[i + j] >= 0x20 && buf[i + j] < 0x7f) ? static_cast<char>(buf[i + j]) : '.';
+            }
+            // Pad if last line is short
+            for (size_t j = size - i; j < 16; j++) {
+                hex_dump += "   ";
+            }
+            hex_dump += " " + ascii + "\n";
+        }
+
+        json j;
+        j["address"] = fmt::format("0x{:X}", *addr);
+        j["size"] = size;
+        j["hex_dump"] = hex_dump;
+
+        // Also provide raw hex bytes
+        std::string raw_hex;
+        for (size_t i = 0; i < size; i++) {
+            raw_hex += fmt::format("{:02X}", buf[i]);
+        }
+        j["raw_hex"] = raw_hex;
+
+        json_response(res, j);
+    });
+
+    m_server->Get("/api/memory/read_typed", [rg](const httplib::Request& req, httplib::Response& res) {
+        auto& proc = rg->process();
+        if (!proc || proc->process_id() == 0) {
+            json_error(res, "Not attached to a process");
+            return;
+        }
+
+        auto addr_str = req.get_param_value("address");
+        auto type_str = req.get_param_value("type");
+        auto count_str = req.get_param_value("count");
+        if (addr_str.empty() || type_str.empty()) {
+            json_error(res, "Required params: address, type. Optional: count");
+            return;
+        }
+
+        auto addr = parse_addr_param(addr_str);
+        if (!addr) { json_error(res, "Invalid address"); return; }
+
+        int count = 1;
+        if (!count_str.empty()) count = std::clamp(std::stoi(count_str), 1, 50);
+
+        auto values = json::array();
+
+        for (int i = 0; i < count; i++) {
+            auto cur = *addr;
+
+            if (type_str == "u8") {
+                auto v = proc->read<uint8_t>(cur); values.push_back(v ? json(*v) : json(nullptr)); *addr += 1;
+            } else if (type_str == "i8") {
+                auto v = proc->read<int8_t>(cur); values.push_back(v ? json(*v) : json(nullptr)); *addr += 1;
+            } else if (type_str == "u16") {
+                auto v = proc->read<uint16_t>(cur); values.push_back(v ? json(*v) : json(nullptr)); *addr += 2;
+            } else if (type_str == "i16") {
+                auto v = proc->read<int16_t>(cur); values.push_back(v ? json(*v) : json(nullptr)); *addr += 2;
+            } else if (type_str == "u32") {
+                auto v = proc->read<uint32_t>(cur); values.push_back(v ? json(*v) : json(nullptr)); *addr += 4;
+            } else if (type_str == "i32") {
+                auto v = proc->read<int32_t>(cur); values.push_back(v ? json(*v) : json(nullptr)); *addr += 4;
+            } else if (type_str == "u64") {
+                auto v = proc->read<uint64_t>(cur); values.push_back(v ? json(fmt::format("0x{:X}", *v)) : json(nullptr)); *addr += 8;
+            } else if (type_str == "i64") {
+                auto v = proc->read<int64_t>(cur); values.push_back(v ? json(*v) : json(nullptr)); *addr += 8;
+            } else if (type_str == "f32") {
+                auto v = proc->read<float>(cur); values.push_back(v ? json(*v) : json(nullptr)); *addr += 4;
+            } else if (type_str == "f64") {
+                auto v = proc->read<double>(cur); values.push_back(v ? json(*v) : json(nullptr)); *addr += 8;
+            } else if (type_str == "ptr") {
+                auto v = proc->read<uintptr_t>(cur); values.push_back(v ? json(fmt::format("0x{:X}", *v)) : json(nullptr)); *addr += sizeof(uintptr_t);
+            } else {
+                json_error(res, "Unknown type. Supported: u8,i8,u16,i16,u32,i32,u64,i64,f32,f64,ptr");
+                return;
+            }
+        }
+
+        json j;
+        j["address"] = addr_str;
+        j["type"] = type_str;
+        j["count"] = count;
+        j["values"] = values;
+        json_response(res, j);
+    });
+
+    m_server->Post("/api/memory/write", [rg](const httplib::Request& req, httplib::Response& res) {
+        auto& proc = rg->process();
+        if (!proc || proc->process_id() == 0) {
+            json_error(res, "Not attached to a process");
+            return;
+        }
+
+        try {
+            auto body = json::parse(req.body);
+            auto addr_str = body.value("address", "");
+            auto type_str = body.value("type", "");
+
+            auto addr = parse_addr_param(addr_str);
+            if (!addr) { json_error(res, "Invalid address"); return; }
+
+            bool ok = false;
+            if (type_str == "u8") ok = proc->write<uint8_t>(*addr, body["value"].get<uint8_t>());
+            else if (type_str == "i8") ok = proc->write<int8_t>(*addr, body["value"].get<int8_t>());
+            else if (type_str == "u16") ok = proc->write<uint16_t>(*addr, body["value"].get<uint16_t>());
+            else if (type_str == "i16") ok = proc->write<int16_t>(*addr, body["value"].get<int16_t>());
+            else if (type_str == "u32") ok = proc->write<uint32_t>(*addr, body["value"].get<uint32_t>());
+            else if (type_str == "i32") ok = proc->write<int32_t>(*addr, body["value"].get<int32_t>());
+            else if (type_str == "u64") ok = proc->write<uint64_t>(*addr, body["value"].get<uint64_t>());
+            else if (type_str == "i64") ok = proc->write<int64_t>(*addr, body["value"].get<int64_t>());
+            else if (type_str == "f32") ok = proc->write<float>(*addr, body["value"].get<float>());
+            else if (type_str == "f64") ok = proc->write<double>(*addr, body["value"].get<double>());
+            else { json_error(res, "Unknown type"); return; }
+
+            json_response(res, json{{"status", ok ? "ok" : "write_failed"}});
+        } catch (const std::exception& e) {
+            json_error(res, e.what());
+        }
+    });
+
+    m_server->Get("/api/memory/read_string", [rg](const httplib::Request& req, httplib::Response& res) {
+        auto& proc = rg->process();
+        if (!proc || proc->process_id() == 0) {
+            json_error(res, "Not attached to a process");
+            return;
+        }
+
+        auto addr_str = req.get_param_value("address");
+        auto max_len_str = req.get_param_value("max_length");
+        if (addr_str.empty()) { json_error(res, "Required param: address"); return; }
+
+        auto addr = parse_addr_param(addr_str);
+        if (!addr) { json_error(res, "Invalid address"); return; }
+
+        size_t max_len = 256;
+        if (!max_len_str.empty()) max_len = std::clamp<size_t>(std::stoull(max_len_str, nullptr, 0), 1, 4096);
+
+        std::string result;
+        for (size_t i = 0; i < max_len; i++) {
+            auto byte = proc->read<uint8_t>(*addr + i);
+            if (!byte || *byte == 0) break;
+            result += static_cast<char>(*byte);
+        }
+
+        json_response(res, json{{"address", addr_str}, {"value", result}, {"length", result.size()}});
+    });
+
+    m_server->Get("/api/modules", [rg](const httplib::Request&, httplib::Response& res) {
+        auto& proc = rg->process();
+        if (!proc || proc->process_id() == 0) {
+            json_error(res, "Not attached to a process");
+            return;
+        }
+
+        auto arr = json::array();
+        for (auto& mod : proc->modules()) {
+            arr.push_back(json{
+                {"name", mod.name},
+                {"start", fmt::format("0x{:X}", mod.start)},
+                {"end", fmt::format("0x{:X}", mod.end)},
+                {"size", mod.size}
+            });
+        }
+        json_response(res, arr);
+    });
+
+    m_server->Get("/api/allocations", [rg](const httplib::Request&, httplib::Response& res) {
+        auto& proc = rg->process();
+        if (!proc || proc->process_id() == 0) {
+            json_error(res, "Not attached to a process");
+            return;
+        }
+
+        auto arr = json::array();
+        for (auto& alloc : proc->allocations()) {
+            arr.push_back(json{
+                {"start", fmt::format("0x{:X}", alloc.start)},
+                {"end", fmt::format("0x{:X}", alloc.end)},
+                {"size", alloc.size},
+                {"read", alloc.read},
+                {"write", alloc.write},
+                {"execute", alloc.execute}
+            });
+        }
+        json_response(res, arr);
+    });
+
+    // ── Genny File Operations ────────────────────────────────────────────
+    m_server->Get("/api/genny/content", [rg](const httplib::Request&, httplib::Response& res) {
+        auto& filepath = rg->open_filepath();
+        if (filepath.empty()) {
+            json_error(res, "No file open");
+            return;
+        }
+
+        try {
+            std::ifstream f{filepath};
+            std::string content{std::istreambuf_iterator<char>(f), {}};
+            json_response(res, json{{"path", filepath.string()}, {"content", content}});
+        } catch (const std::exception& e) {
+            json_error(res, e.what(), 500);
+        }
+    });
+
+    m_server->Post("/api/genny/content", [this, rg](const httplib::Request& req, httplib::Response& res) {
+        auto& filepath = rg->open_filepath();
+        if (filepath.empty()) {
+            json_error(res, "No file open");
+            return;
+        }
+
+        try {
+            auto body = json::parse(req.body);
+            auto content = body.value("content", "");
+
+            std::ofstream f{filepath};
+            f << content;
+            f.close();
+
+            // Request re-parse on main thread
+            m_reparse_requested.store(true);
+
+            json_response(res, json{{"status", "ok"}, {"path", filepath.string()}});
+        } catch (const std::exception& e) {
+            json_error(res, e.what(), 500);
+        }
+    });
+
+    m_server->Get("/api/genny/path", [rg](const httplib::Request&, httplib::Response& res) {
+        auto& filepath = rg->open_filepath();
+        json_response(res, json{{"path", filepath.empty() ? "" : filepath.string()}});
+    });
+
+    m_server->Post("/api/genny/open", [this](const httplib::Request& req, httplib::Response& res) {
+        try {
+            auto body = json::parse(req.body);
+            auto path = body.value("path", "");
+            if (path.empty()) { json_error(res, "Required: path"); return; }
+            if (!std::filesystem::exists(path)) { json_error(res, "File not found: " + path); return; }
+
+            {
+                std::scoped_lock lk{m_deferred_lock};
+                m_deferred_open = DeferredOpen{path};
+            }
+            json_response(res, json{{"status", "ok"}, {"path", path}});
+        } catch (const std::exception& e) {
+            json_error(res, e.what());
+        }
+    });
+
+    m_server->Post("/api/genny/new", [this](const httplib::Request& req, httplib::Response& res) {
+        try {
+            auto body = json::parse(req.body);
+            auto path = body.value("path", "");
+            auto content = body.value("content", "");
+
+            if (path.empty()) { json_error(res, "Required: path"); return; }
+
+            // Ensure .genny extension
+            std::filesystem::path fpath{path};
+            if (fpath.extension() != ".genny") {
+                fpath.replace_extension(".genny");
+            }
+
+            // Provide default content if none given
+            if (content.empty()) {
+                content = "type int 4 [[i32]]\n\nstruct MyStruct {\n    int value @ 0\n}\n";
+            }
+
+            std::ofstream f{fpath};
+            f << content;
+            f.close();
+
+            {
+                std::scoped_lock lk{m_deferred_lock};
+                m_deferred_open = DeferredOpen{fpath.string()};
+            }
+            json_response(res, json{{"status", "ok"}, {"path", fpath.string()}});
+        } catch (const std::exception& e) {
+            json_error(res, e.what(), 500);
+        }
+    });
+
+    m_server->Post("/api/genny/reload", [this](const httplib::Request&, httplib::Response& res) {
+        m_reparse_requested.store(true);
+        json_response(res, json{{"status", "ok"}});
+    });
+
+    // ── Type Introspection ───────────────────────────────────────────────
+    m_server->Get("/api/types", [rg](const httplib::Request&, httplib::Response& res) {
+        auto& sdk = rg->sdk();
+        if (!sdk) { json_error(res, "No SDK loaded (open a .genny file first)"); return; }
+
+        std::unordered_set<sdkgenny::Struct*> structs{};
+        sdk->global_ns()->get_all_in_children<sdkgenny::Struct>(structs);
+
+        auto arr = json::array();
+        for (auto* s : structs) {
+            // Build fully qualified name
+            std::vector<std::string> parts;
+            for (auto* p = s->owner<sdkgenny::Object>(); p && !p->is_a<sdkgenny::Sdk>(); p = p->owner<sdkgenny::Object>()) {
+                if (!p->name().empty()) parts.push_back(p->name());
+            }
+            std::reverse(parts.begin(), parts.end());
+            std::string fqn;
+            for (auto& part : parts) fqn += part + ".";
+            fqn += s->name();
+
+            arr.push_back(json{{"name", fqn}, {"size", s->size()}});
+        }
+
+        json_response(res, arr);
+    });
+
+    m_server->Get("/api/type", [rg](const httplib::Request& req, httplib::Response& res) {
+        auto& sdk = rg->sdk();
+        if (!sdk) { json_error(res, "No SDK loaded"); return; }
+
+        auto name = req.get_param_value("name");
+        if (name.empty()) { json_error(res, "Required param: name"); return; }
+
+        // Find the struct by name (support dot-separated and plain names)
+        std::unordered_set<sdkgenny::Struct*> structs{};
+        sdk->global_ns()->get_all_in_children<sdkgenny::Struct>(structs);
+
+        sdkgenny::Struct* found = nullptr;
+        for (auto* s : structs) {
+            // Build FQN
+            std::vector<std::string> parts;
+            for (auto* p = s->owner<sdkgenny::Object>(); p && !p->is_a<sdkgenny::Sdk>(); p = p->owner<sdkgenny::Object>()) {
+                if (!p->name().empty()) parts.push_back(p->name());
+            }
+            std::reverse(parts.begin(), parts.end());
+            std::string fqn;
+            for (auto& part : parts) fqn += part + ".";
+            fqn += s->name();
+
+            if (fqn == name || s->name() == name) {
+                found = s;
+                break;
+            }
+        }
+
+        if (!found) { json_error(res, "Type not found: " + name, 404); return; }
+
+        json_response(res, serialize_struct(found));
+    });
+
+    m_server->Get("/api/type/address", [rg](const httplib::Request& req, httplib::Response& res) {
+        auto name = req.get_param_value("name");
+        if (name.empty()) { json_error(res, "Required param: name"); return; }
+
+        auto& project = rg->project();
+        auto it = project.type_addresses.find(name);
+        if (it != project.type_addresses.end()) {
+            json_response(res, json{{"name", name}, {"address", it->second}});
+        } else {
+            json_response(res, json{{"name", name}, {"address", nullptr}});
+        }
+    });
+
+    m_server->Post("/api/type/select", [this](const httplib::Request& req, httplib::Response& res) {
+        try {
+            auto body = json::parse(req.body);
+            auto name = body.value("name", "");
+            auto address = body.value("address", "");
+            if (name.empty()) { json_error(res, "Required: name"); return; }
+
+            {
+                std::scoped_lock lk{m_deferred_lock};
+                m_deferred_type_select = DeferredTypeSelect{name, address};
+            }
+            json_response(res, json{{"status", "ok"}, {"name", name}, {"address", address}});
+        } catch (const std::exception& e) {
+            json_error(res, e.what());
+        }
+    });
+
+    // ── Lua Scripting ────────────────────────────────────────────────────
+    m_server->Post("/api/lua/eval", [rg](const httplib::Request& req, httplib::Response& res) {
+        try {
+            auto body = json::parse(req.body);
+            auto code = body.value("code", "");
+            if (code.empty()) { json_error(res, "Required: code"); return; }
+
+            // Install capture sink, run code, remove sink
+            auto capture = std::make_shared<CaptureSink<std::mutex>>();
+            capture->set_pattern("%v"); // Just the message, no timestamp/level for captured output
+            spdlog::default_logger()->sinks().push_back(capture);
+
+            std::string result_str;
+            bool success = true;
+            std::string error_msg;
+
+            {
+                auto& lua_lock = rg->lua_lock();
+                std::scoped_lock lk{lua_lock};
+                auto& lua = rg->lua();
+
+                try {
+                    // Try "return <code>" first to get expression values
+                    auto result = lua.safe_script(std::string{"return "} + code);
+
+                    if (result.valid()) {
+                        auto obj = result.get<sol::object>();
+                        if (obj.get_type() != sol::type::none && obj.get_type() != sol::type::lua_nil) {
+                            obj.push();
+                            auto str = luaL_tolstring(lua, -1, nullptr);
+                            if (str) result_str = str;
+                            lua_pop(lua, 2);
+                        }
+                    }
+                } catch (...) {
+                    // Expression parse failed, try as statement
+                    try {
+                        auto result = lua.safe_script(code);
+                        if (!result.valid()) {
+                            success = false;
+                            error_msg = "Script execution failed";
+                        }
+                    } catch (const std::exception& e) {
+                        success = false;
+                        error_msg = e.what();
+                    }
+                }
+            }
+
+            // Remove capture sink
+            auto& sinks = spdlog::default_logger()->sinks();
+            sinks.erase(std::remove(sinks.begin(), sinks.end(), capture), sinks.end());
+
+            json j;
+            j["success"] = success;
+            j["output"] = capture->buffer();
+            if (!result_str.empty()) j["result"] = result_str;
+            if (!error_msg.empty()) j["error"] = error_msg;
+
+            json_response(res, j);
+        } catch (const std::exception& e) {
+            json_error(res, e.what(), 500);
+        }
+    });
+
+    m_server->Post("/api/lua/exec_file", [rg](const httplib::Request& req, httplib::Response& res) {
+        try {
+            auto body = json::parse(req.body);
+            auto path = body.value("path", "");
+            if (path.empty()) { json_error(res, "Required: path"); return; }
+            if (!std::filesystem::exists(path)) { json_error(res, "File not found: " + path); return; }
+
+            auto capture = std::make_shared<CaptureSink<std::mutex>>();
+            capture->set_pattern("%v");
+            spdlog::default_logger()->sinks().push_back(capture);
+
+            bool success = true;
+            std::string error_msg;
+
+            {
+                auto& lua_lock = rg->lua_lock();
+                std::scoped_lock lk{lua_lock};
+                auto& lua = rg->lua();
+
+                try {
+                    lua.do_file(path);
+                } catch (const std::exception& e) {
+                    success = false;
+                    error_msg = e.what();
+                }
+            }
+
+            auto& sinks = spdlog::default_logger()->sinks();
+            sinks.erase(std::remove(sinks.begin(), sinks.end(), capture), sinks.end());
+
+            json j;
+            j["success"] = success;
+            j["output"] = capture->buffer();
+            if (!error_msg.empty()) j["error"] = error_msg;
+            json_response(res, j);
+        } catch (const std::exception& e) {
+            json_error(res, e.what(), 500);
+        }
+    });
+
+    m_server->Post("/api/lua/reset", [rg](const httplib::Request&, httplib::Response& res) {
+        auto& lua_lock = rg->lua_lock();
+        std::scoped_lock lk{lua_lock};
+        rg->reset_lua_state_api();
+        json_response(res, json{{"status", "ok"}});
+    });
+
+    m_server->Get("/api/lua/script", [](const httplib::Request& req, httplib::Response& res) {
+        auto path = req.get_param_value("path");
+        if (path.empty()) { json_error(res, "Required param: path"); return; }
+        if (!std::filesystem::exists(path)) { json_error(res, "File not found: " + path, 404); return; }
+
+        try {
+            std::ifstream f{path};
+            std::string content{std::istreambuf_iterator<char>(f), {}};
+            json_response(res, json{{"path", path}, {"content", content}});
+        } catch (const std::exception& e) {
+            json_error(res, e.what(), 500);
+        }
+    });
+
+    m_server->Post("/api/lua/script", [](const httplib::Request& req, httplib::Response& res) {
+        try {
+            auto body = json::parse(req.body);
+            auto path = body.value("path", "");
+            auto content = body.value("content", "");
+            if (path.empty()) { json_error(res, "Required: path"); return; }
+
+            // Ensure directory exists
+            auto dir = std::filesystem::path{path}.parent_path();
+            if (!dir.empty()) std::filesystem::create_directories(dir);
+
+            std::ofstream f{path};
+            f << content;
+            f.close();
+
+            json_response(res, json{{"status", "ok"}, {"path", path}});
+        } catch (const std::exception& e) {
+            json_error(res, e.what(), 500);
+        }
+    });
+
+    // ── Project ──────────────────────────────────────────────────────────
+    m_server->Get("/api/project", [rg](const httplib::Request&, httplib::Response& res) {
+        auto& project = rg->project();
+        json j;
+        j["process_name"] = project.process_name;
+        j["process_id"] = project.process_id;
+        j["type_chosen"] = project.type_chosen;
+        j["type_addresses"] = project.type_addresses;
+        j["extension_header"] = project.extension_header;
+        j["extension_source"] = project.extension_source;
+
+        auto tabs = json::array();
+        for (auto& tab : project.tabs) {
+            tabs.push_back(json{{"name", tab.name}, {"type_name", tab.type_name}, {"address", tab.address}});
+        }
+        j["tabs"] = tabs;
+        j["active_tab_index"] = project.active_tab_index;
+
+        json_response(res, j);
+    });
+
+    // ── RTTI ─────────────────────────────────────────────────────────────
+#ifdef _WIN32
+    m_server->Get("/api/rtti/typename", [rg](const httplib::Request& req, httplib::Response& res) {
+        auto& proc = rg->process();
+        if (!proc || proc->process_id() == 0) { json_error(res, "Not attached"); return; }
+
+        auto addr_str = req.get_param_value("address");
+        auto addr = parse_addr_param(addr_str);
+        if (!addr) { json_error(res, "Invalid address"); return; }
+
+        auto* wp = dynamic_cast<arch::WindowsProcess*>(proc.get());
+        if (!wp) { json_error(res, "RTTI only available on Windows processes"); return; }
+
+        auto name = wp->get_typename(*addr);
+        if (name) {
+            json_response(res, json{{"address", addr_str}, {"typename", *name}});
+        } else {
+            json_response(res, json{{"address", addr_str}, {"typename", nullptr}});
+        }
+    });
+
+    m_server->Get("/api/rtti/vtable_typename", [rg](const httplib::Request& req, httplib::Response& res) {
+        auto& proc = rg->process();
+        if (!proc || proc->process_id() == 0) { json_error(res, "Not attached"); return; }
+
+        auto addr_str = req.get_param_value("address");
+        auto addr = parse_addr_param(addr_str);
+        if (!addr) { json_error(res, "Invalid address"); return; }
+
+        auto* wp = dynamic_cast<arch::WindowsProcess*>(proc.get());
+        if (!wp) { json_error(res, "RTTI only available on Windows processes"); return; }
+
+        auto name = wp->get_typename_from_vtable(*addr);
+        if (name) {
+            json_response(res, json{{"address", addr_str}, {"typename", *name}});
+        } else {
+            json_response(res, json{{"address", addr_str}, {"typename", nullptr}});
+        }
+    });
+#endif
+
+    // ── Help ─────────────────────────────────────────────────────────────
+    m_server->Get("/api/help", [](const httplib::Request&, httplib::Response& res) {
+        // Try to find AGENT.md relative to the executable
+        auto exe_dir = std::filesystem::current_path();
+
+        for (auto& candidate : {
+            exe_dir / "AGENT.md",
+            exe_dir / ".." / "AGENT.md",
+            exe_dir / "mcp-server" / "AGENT.md",
+        }) {
+            if (std::filesystem::exists(candidate)) {
+                std::ifstream f{candidate};
+                std::string content{std::istreambuf_iterator<char>(f), {}};
+                res.set_content(content, "text/markdown");
+                return;
+            }
+        }
+
+        json_error(res, "AGENT.md not found", 404);
+    });
+}

--- a/src/Api.cpp
+++ b/src/Api.cpp
@@ -225,9 +225,12 @@ void Api::register_routes() {
         std::shared_lock state_lk{rg->state_mtx()};
         json j;
         auto& proc = rg->process();
+        auto& project = rg->project();
         j["attached"] = proc && proc->process_id() != 0;
         j["process_id"] = proc ? proc->process_id() : 0;
-        // Access project fields via the accessors we have
+        j["process_name"] = project.process_name;
+        auto& filepath = rg->open_filepath();
+        j["open_file"] = filepath.empty() ? "" : filepath.string();
         if (rg->type()) {
             j["current_type"] = rg->type()->name();
         } else {
@@ -735,10 +738,12 @@ void Api::register_routes() {
 
             // Create a per-request logger to capture print() output without mutating the shared logger
             auto capture = std::make_shared<CaptureSink<std::mutex>>();
-            capture->set_pattern("%v");
 
+            // The eval logger exists only to capture print() output via spdlog::info().
+            // The capture sink uses "%v" (raw message only, no timestamp/level prefix).
+            // Do NOT call eval_logger->set_pattern() — it would override the sink's pattern.
             auto eval_logger = std::make_shared<spdlog::logger>("api_eval", capture);
-            eval_logger->set_pattern("[%H:%M:%S] [%l] %v");
+            capture->set_pattern("%v");
 
             std::string result_str;
             bool success = true;
@@ -797,10 +802,8 @@ void Api::register_routes() {
             if (!std::filesystem::exists(path)) { json_error(res, "File not found: " + path); return; }
 
             auto capture = std::make_shared<CaptureSink<std::mutex>>();
-            capture->set_pattern("%v");
-
             auto eval_logger = std::make_shared<spdlog::logger>("api_exec", capture);
-            eval_logger->set_pattern("[%H:%M:%S] [%l] %v");
+            capture->set_pattern("%v");
 
             bool success = true;
             std::string error_msg;

--- a/src/Api.cpp
+++ b/src/Api.cpp
@@ -2,6 +2,7 @@
 #include <filesystem>
 #include <fstream>
 #include <mutex>
+#include <shared_mutex>
 
 #include <fmt/format.h>
 #include <httplib.h>
@@ -204,8 +205,24 @@ void Api::server_thread_fn() {
 void Api::register_routes() {
     auto* rg = m_regenny;
 
+    // Global exception handler — catches any unhandled exception from route handlers
+    // (e.g. std::stoull/std::stoi on invalid input) and returns a 500 JSON error
+    // instead of crashing the server thread.
+    m_server->set_exception_handler([](const httplib::Request&, httplib::Response& res, std::exception_ptr ep) {
+        try {
+            if (ep) std::rethrow_exception(ep);
+        } catch (const std::exception& e) {
+            res.status = 500;
+            res.set_content(json{{"error", e.what()}}.dump(), "application/json");
+        } catch (...) {
+            res.status = 500;
+            res.set_content(json{{"error", "unknown exception"}}.dump(), "application/json");
+        }
+    });
+
     // ── Status ───────────────────────────────────────────────────────────
     m_server->Get("/api/status", [rg](const httplib::Request&, httplib::Response& res) {
+        std::shared_lock state_lk{rg->state_mtx()};
         json j;
         auto& proc = rg->process();
         j["attached"] = proc && proc->process_id() != 0;
@@ -223,6 +240,7 @@ void Api::register_routes() {
 
     // ── Process Management ───────────────────────────────────────────────
     m_server->Get("/api/processes", [rg](const httplib::Request&, httplib::Response& res) {
+        std::shared_lock state_lk{rg->state_mtx()};
         // We need helpers to list processes, but that's private.
         // Use arch::make_helpers() directly.
         auto helpers = arch::make_helpers();
@@ -282,6 +300,7 @@ void Api::register_routes() {
 
     // ── Memory Operations ────────────────────────────────────────────────
     m_server->Get("/api/memory/read", [rg](const httplib::Request& req, httplib::Response& res) {
+        std::shared_lock state_lk{rg->state_mtx()};
         auto& proc = rg->process();
         if (!proc || proc->process_id() == 0) {
             json_error(res, "Not attached to a process");
@@ -338,6 +357,7 @@ void Api::register_routes() {
     });
 
     m_server->Get("/api/memory/read_typed", [rg](const httplib::Request& req, httplib::Response& res) {
+        std::shared_lock state_lk{rg->state_mtx()};
         auto& proc = rg->process();
         if (!proc || proc->process_id() == 0) {
             json_error(res, "Not attached to a process");
@@ -400,6 +420,7 @@ void Api::register_routes() {
     });
 
     m_server->Post("/api/memory/write", [rg](const httplib::Request& req, httplib::Response& res) {
+        std::shared_lock state_lk{rg->state_mtx()};
         auto& proc = rg->process();
         if (!proc || proc->process_id() == 0) {
             json_error(res, "Not attached to a process");
@@ -434,6 +455,7 @@ void Api::register_routes() {
     });
 
     m_server->Get("/api/memory/read_string", [rg](const httplib::Request& req, httplib::Response& res) {
+        std::shared_lock state_lk{rg->state_mtx()};
         auto& proc = rg->process();
         if (!proc || proc->process_id() == 0) {
             json_error(res, "Not attached to a process");
@@ -461,6 +483,7 @@ void Api::register_routes() {
     });
 
     m_server->Get("/api/modules", [rg](const httplib::Request&, httplib::Response& res) {
+        std::shared_lock state_lk{rg->state_mtx()};
         auto& proc = rg->process();
         if (!proc || proc->process_id() == 0) {
             json_error(res, "Not attached to a process");
@@ -480,6 +503,7 @@ void Api::register_routes() {
     });
 
     m_server->Get("/api/allocations", [rg](const httplib::Request&, httplib::Response& res) {
+        std::shared_lock state_lk{rg->state_mtx()};
         auto& proc = rg->process();
         if (!proc || proc->process_id() == 0) {
             json_error(res, "Not attached to a process");
@@ -502,6 +526,7 @@ void Api::register_routes() {
 
     // ── Genny File Operations ────────────────────────────────────────────
     m_server->Get("/api/genny/content", [rg](const httplib::Request&, httplib::Response& res) {
+        std::shared_lock state_lk{rg->state_mtx()};
         auto& filepath = rg->open_filepath();
         if (filepath.empty()) {
             json_error(res, "No file open");
@@ -510,6 +535,10 @@ void Api::register_routes() {
 
         try {
             std::ifstream f{filepath};
+            if (!f.is_open()) {
+                json_error(res, "Failed to open file", 500);
+                return;
+            }
             std::string content{std::istreambuf_iterator<char>(f), {}};
             json_response(res, json{{"path", filepath.string()}, {"content", content}});
         } catch (const std::exception& e) {
@@ -518,6 +547,7 @@ void Api::register_routes() {
     });
 
     m_server->Post("/api/genny/content", [this, rg](const httplib::Request& req, httplib::Response& res) {
+        std::shared_lock state_lk{rg->state_mtx()};
         auto& filepath = rg->open_filepath();
         if (filepath.empty()) {
             json_error(res, "No file open");
@@ -542,6 +572,7 @@ void Api::register_routes() {
     });
 
     m_server->Get("/api/genny/path", [rg](const httplib::Request&, httplib::Response& res) {
+        std::shared_lock state_lk{rg->state_mtx()};
         auto& filepath = rg->open_filepath();
         json_response(res, json{{"path", filepath.empty() ? "" : filepath.string()}});
     });
@@ -603,6 +634,7 @@ void Api::register_routes() {
 
     // ── Type Introspection ───────────────────────────────────────────────
     m_server->Get("/api/types", [rg](const httplib::Request&, httplib::Response& res) {
+        std::shared_lock state_lk{rg->state_mtx()};
         auto& sdk = rg->sdk();
         if (!sdk) { json_error(res, "No SDK loaded (open a .genny file first)"); return; }
 
@@ -628,6 +660,7 @@ void Api::register_routes() {
     });
 
     m_server->Get("/api/type", [rg](const httplib::Request& req, httplib::Response& res) {
+        std::shared_lock state_lk{rg->state_mtx()};
         auto& sdk = rg->sdk();
         if (!sdk) { json_error(res, "No SDK loaded"); return; }
 
@@ -662,6 +695,7 @@ void Api::register_routes() {
     });
 
     m_server->Get("/api/type/address", [rg](const httplib::Request& req, httplib::Response& res) {
+        std::shared_lock state_lk{rg->state_mtx()};
         auto name = req.get_param_value("name");
         if (name.empty()) { json_error(res, "Required param: name"); return; }
 
@@ -693,15 +727,18 @@ void Api::register_routes() {
 
     // ── Lua Scripting ────────────────────────────────────────────────────
     m_server->Post("/api/lua/eval", [rg](const httplib::Request& req, httplib::Response& res) {
+        std::shared_lock state_lk{rg->state_mtx()};
         try {
             auto body = json::parse(req.body);
             auto code = body.value("code", "");
             if (code.empty()) { json_error(res, "Required: code"); return; }
 
-            // Install capture sink, run code, remove sink
+            // Create a per-request logger to capture print() output without mutating the shared logger
             auto capture = std::make_shared<CaptureSink<std::mutex>>();
-            capture->set_pattern("%v"); // Just the message, no timestamp/level for captured output
-            spdlog::default_logger()->sinks().push_back(capture);
+            capture->set_pattern("%v");
+
+            auto eval_logger = std::make_shared<spdlog::logger>("api_eval", capture);
+            eval_logger->set_pattern("[%H:%M:%S] [%l] %v");
 
             std::string result_str;
             bool success = true;
@@ -712,37 +749,32 @@ void Api::register_routes() {
                 std::scoped_lock lk{lua_lock};
                 auto& lua = rg->lua();
 
-                try {
-                    // Try "return <code>" first to get expression values
-                    auto result = lua.safe_script(std::string{"return "} + code);
+                auto prev_logger = spdlog::default_logger();
+                spdlog::set_default_logger(eval_logger);
 
-                    if (result.valid()) {
-                        auto obj = result.get<sol::object>();
-                        if (obj.get_type() != sol::type::none && obj.get_type() != sol::type::lua_nil) {
-                            obj.push();
-                            auto str = luaL_tolstring(lua, -1, nullptr);
-                            if (str) result_str = str;
-                            lua_pop(lua, 2);
-                        }
+                // Try as expression first
+                auto result = lua.safe_script(std::string{"return "} + code, sol::script_pass_on_error);
+
+                if (result.valid()) {
+                    auto obj = result.get<sol::object>();
+                    if (obj.get_type() != sol::type::none && obj.get_type() != sol::type::lua_nil) {
+                        obj.push();
+                        auto str = luaL_tolstring(lua, -1, nullptr);
+                        if (str) result_str = str;
+                        lua_pop(lua, 2);
                     }
-                } catch (...) {
-                    // Expression parse failed, try as statement
-                    try {
-                        auto result = lua.safe_script(code);
-                        if (!result.valid()) {
-                            success = false;
-                            error_msg = "Script execution failed";
-                        }
-                    } catch (const std::exception& e) {
+                } else {
+                    // Expression failed, try as statement
+                    auto stmt_result = lua.safe_script(code, sol::script_pass_on_error);
+                    if (!stmt_result.valid()) {
                         success = false;
-                        error_msg = e.what();
+                        sol::error err = stmt_result;
+                        error_msg = err.what();
                     }
                 }
-            }
 
-            // Remove capture sink
-            auto& sinks = spdlog::default_logger()->sinks();
-            sinks.erase(std::remove(sinks.begin(), sinks.end(), capture), sinks.end());
+                spdlog::set_default_logger(prev_logger);
+            }
 
             json j;
             j["success"] = success;
@@ -757,6 +789,7 @@ void Api::register_routes() {
     });
 
     m_server->Post("/api/lua/exec_file", [rg](const httplib::Request& req, httplib::Response& res) {
+        std::shared_lock state_lk{rg->state_mtx()};
         try {
             auto body = json::parse(req.body);
             auto path = body.value("path", "");
@@ -765,7 +798,9 @@ void Api::register_routes() {
 
             auto capture = std::make_shared<CaptureSink<std::mutex>>();
             capture->set_pattern("%v");
-            spdlog::default_logger()->sinks().push_back(capture);
+
+            auto eval_logger = std::make_shared<spdlog::logger>("api_exec", capture);
+            eval_logger->set_pattern("[%H:%M:%S] [%l] %v");
 
             bool success = true;
             std::string error_msg;
@@ -775,16 +810,18 @@ void Api::register_routes() {
                 std::scoped_lock lk{lua_lock};
                 auto& lua = rg->lua();
 
-                try {
-                    lua.do_file(path);
-                } catch (const std::exception& e) {
-                    success = false;
-                    error_msg = e.what();
-                }
-            }
+                auto prev_logger = spdlog::default_logger();
+                spdlog::set_default_logger(eval_logger);
 
-            auto& sinks = spdlog::default_logger()->sinks();
-            sinks.erase(std::remove(sinks.begin(), sinks.end(), capture), sinks.end());
+                auto result = lua.safe_script_file(path, sol::script_pass_on_error);
+                if (!result.valid()) {
+                    success = false;
+                    sol::error err = result;
+                    error_msg = err.what();
+                }
+
+                spdlog::set_default_logger(prev_logger);
+            }
 
             json j;
             j["success"] = success;
@@ -797,6 +834,7 @@ void Api::register_routes() {
     });
 
     m_server->Post("/api/lua/reset", [rg](const httplib::Request&, httplib::Response& res) {
+        std::shared_lock state_lk{rg->state_mtx()};
         auto& lua_lock = rg->lua_lock();
         std::scoped_lock lk{lua_lock};
         rg->reset_lua_state_api();
@@ -810,6 +848,10 @@ void Api::register_routes() {
 
         try {
             std::ifstream f{path};
+            if (!f.is_open()) {
+                json_error(res, "Failed to open file", 500);
+                return;
+            }
             std::string content{std::istreambuf_iterator<char>(f), {}};
             json_response(res, json{{"path", path}, {"content", content}});
         } catch (const std::exception& e) {
@@ -840,6 +882,7 @@ void Api::register_routes() {
 
     // ── Project ──────────────────────────────────────────────────────────
     m_server->Get("/api/project", [rg](const httplib::Request&, httplib::Response& res) {
+        std::shared_lock state_lk{rg->state_mtx()};
         auto& project = rg->project();
         json j;
         j["process_name"] = project.process_name;
@@ -862,6 +905,7 @@ void Api::register_routes() {
     // ── RTTI ─────────────────────────────────────────────────────────────
 #ifdef _WIN32
     m_server->Get("/api/rtti/typename", [rg](const httplib::Request& req, httplib::Response& res) {
+        std::shared_lock state_lk{rg->state_mtx()};
         auto& proc = rg->process();
         if (!proc || proc->process_id() == 0) { json_error(res, "Not attached"); return; }
 
@@ -881,6 +925,7 @@ void Api::register_routes() {
     });
 
     m_server->Get("/api/rtti/vtable_typename", [rg](const httplib::Request& req, httplib::Response& res) {
+        std::shared_lock state_lk{rg->state_mtx()};
         auto& proc = rg->process();
         if (!proc || proc->process_id() == 0) { json_error(res, "Not attached"); return; }
 
@@ -912,6 +957,9 @@ void Api::register_routes() {
         }) {
             if (std::filesystem::exists(candidate)) {
                 std::ifstream f{candidate};
+                if (!f.is_open()) {
+                    continue;
+                }
                 std::string content{std::istreambuf_iterator<char>(f), {}};
                 res.set_content(content, "text/markdown");
                 return;

--- a/src/Api.cpp
+++ b/src/Api.cpp
@@ -736,13 +736,13 @@ void Api::register_routes() {
             auto code = body.value("code", "");
             if (code.empty()) { json_error(res, "Required: code"); return; }
 
-            // Create a per-request logger to capture print() output without mutating the shared logger
+            // Create a per-request logger with two sinks:
+            //   1. CaptureSink — raw "%v" output for the API JSON response
+            //   2. UI logger sink — so the user sees output in the ReGenny Log panel
             auto capture = std::make_shared<CaptureSink<std::mutex>>();
-
-            // The eval logger exists only to capture print() output via spdlog::info().
-            // The capture sink uses "%v" (raw message only, no timestamp/level prefix).
-            // Do NOT call eval_logger->set_pattern() — it would override the sink's pattern.
-            auto eval_logger = std::make_shared<spdlog::logger>("api_eval", capture);
+            auto ui_sink = rg->logger().logger()->sinks().front();
+            auto eval_logger = std::make_shared<spdlog::logger>("api_eval",
+                spdlog::sinks_init_list{capture, ui_sink});
             capture->set_pattern("%v");
 
             std::string result_str;
@@ -802,7 +802,9 @@ void Api::register_routes() {
             if (!std::filesystem::exists(path)) { json_error(res, "File not found: " + path); return; }
 
             auto capture = std::make_shared<CaptureSink<std::mutex>>();
-            auto eval_logger = std::make_shared<spdlog::logger>("api_exec", capture);
+            auto ui_sink = rg->logger().logger()->sinks().front();
+            auto eval_logger = std::make_shared<spdlog::logger>("api_exec",
+                spdlog::sinks_init_list{capture, ui_sink});
             capture->set_pattern("%v");
 
             bool success = true;

--- a/src/Api.hpp
+++ b/src/Api.hpp
@@ -1,0 +1,66 @@
+#pragma once
+
+#include <atomic>
+#include <memory>
+#include <string>
+#include <thread>
+
+class ReGenny;
+
+namespace httplib {
+class Server;
+}
+
+// Embedded HTTP API server for MCP integration.
+// Runs on a background thread, provides JSON endpoints for all ReGenny operations.
+class Api {
+public:
+    explicit Api(ReGenny* regenny, int port = 0);
+    ~Api();
+
+    Api(const Api&) = delete;
+    Api& operator=(const Api&) = delete;
+
+    int port() const { return m_port; }
+
+    // Deferred operations — checked by ReGenny::update() on the main thread.
+    // These exist because PEGTL parsing and UI state mutations must happen on the main thread.
+    bool should_reparse() { return m_reparse_requested.exchange(false); }
+    bool should_detach() { return m_detach_requested.exchange(false); }
+
+    struct DeferredAttach {
+        uint32_t pid{};
+        std::string name{};
+    };
+    // Returns nullopt if no attach is pending.
+    std::optional<DeferredAttach> consume_deferred_attach();
+
+    struct DeferredOpen {
+        std::string filepath{};
+    };
+    std::optional<DeferredOpen> consume_deferred_open();
+
+    struct DeferredTypeSelect {
+        std::string type_name{};
+        std::string address{};
+    };
+    std::optional<DeferredTypeSelect> consume_deferred_type_select();
+
+private:
+    void register_routes();
+    void server_thread_fn();
+
+    ReGenny* m_regenny{};
+    int m_port{};
+    std::unique_ptr<httplib::Server> m_server;
+    std::thread m_thread;
+
+    // Deferred operation state — written by HTTP thread, consumed by main thread.
+    std::atomic<bool> m_reparse_requested{false};
+    std::atomic<bool> m_detach_requested{false};
+
+    std::mutex m_deferred_lock;
+    std::optional<DeferredAttach> m_deferred_attach;
+    std::optional<DeferredOpen> m_deferred_open;
+    std::optional<DeferredTypeSelect> m_deferred_type_select;
+};

--- a/src/Api.hpp
+++ b/src/Api.hpp
@@ -1,7 +1,10 @@
 #pragma once
 
 #include <atomic>
+#include <cstdint>
 #include <memory>
+#include <mutex>
+#include <optional>
 #include <string>
 #include <thread>
 

--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -10,6 +10,7 @@ void to_json(nlohmann::json& j, const Config& c) {
     j["display"]["print"] = c.display_print;
     j["refresh_rate"] = c.refresh_rate;
     j["always_on_top"] = c.always_on_top;
+    j["api_enabled"] = c.api_enabled;
 }
 
 void from_json(const nlohmann::json& j, Config& c) {
@@ -31,4 +32,5 @@ void from_json(const nlohmann::json& j, Config& c) {
 
     c.refresh_rate = j.value("refresh_rate", 500);
     c.always_on_top = j.value("always_on_top", false);
+    c.api_enabled = j.value("api_enabled", true);
 }

--- a/src/Config.hpp
+++ b/src/Config.hpp
@@ -15,6 +15,7 @@ struct Config {
     bool display_print{true};
     int refresh_rate{500};
     bool always_on_top{false};
+    bool api_enabled{true};
 };
 
 void to_json(nlohmann::json& j, const Config& c);

--- a/src/Config.hpp
+++ b/src/Config.hpp
@@ -15,7 +15,7 @@ struct Config {
     bool display_print{true};
     int refresh_rate{500};
     bool always_on_top{false};
-    bool api_enabled{true};
+    bool api_enabled{false};
 };
 
 void to_json(nlohmann::json& j, const Config& c);

--- a/src/LoggerUi.cpp
+++ b/src/LoggerUi.cpp
@@ -1,6 +1,11 @@
 #include "LoggerUi.hpp"
 
 void LoggerUi::ui() {
+    // Drain queued messages from background threads into the ImGui buffer.
+    // This is the only place m_buf is mutated, and it runs on the main thread,
+    // so ImGui::TextUnformatted below always reads a stable buffer.
+    m_sink->flush_to(m_buf, m_scroll_to_bottom);
+
     ImGui::BeginChild("logger");
     ImGui::TextUnformatted(m_buf.begin());
 

--- a/src/LoggerUi.hpp
+++ b/src/LoggerUi.hpp
@@ -1,27 +1,44 @@
 #pragma once
 
+#include <mutex>
+#include <string>
+#include <vector>
+
 #include <fmt/format.h>
 #include <imgui.h>
 #include <spdlog/sinks/base_sink.h>
 #include <spdlog/spdlog.h>
 
+// Thread-safe sink that queues formatted messages for main-thread consumption.
+// sink_it_ can be called from any thread; the queued messages are flushed
+// into the ImGuiTextBuffer by LoggerUi::ui() on the main thread.
 template <typename Mutex> class LoggerUiSink : public spdlog::sinks::base_sink<Mutex> {
 public:
-    LoggerUiSink(ImGuiTextBuffer& buf, bool& scroll_to_bottom) : m_buf{buf}, m_scroll_to_bottom{scroll_to_bottom} {}
+    // Drain all queued messages into the target buffer. Call from main thread only.
+    void flush_to(ImGuiTextBuffer& buf, bool& scroll_to_bottom) {
+        std::scoped_lock lk{m_queue_lock};
+        if (m_queue.empty()) return;
+        for (auto& msg : m_queue) {
+            buf.append(msg.c_str());
+        }
+        m_queue.clear();
+        scroll_to_bottom = true;
+    }
 
 protected:
     void sink_it_(const spdlog::details::log_msg& msg) override {
         spdlog::memory_buf_t formatted{};
         spdlog::sinks::base_sink<Mutex>::formatter_->format(msg, formatted);
-        m_buf.append(fmt::to_string(formatted).c_str());
-        m_scroll_to_bottom = true;
+
+        std::scoped_lock lk{m_queue_lock};
+        m_queue.push_back(fmt::to_string(formatted));
     }
 
     void flush_() override {}
 
 private:
-    ImGuiTextBuffer& m_buf{};
-    bool& m_scroll_to_bottom{};
+    std::mutex m_queue_lock;
+    std::vector<std::string> m_queue;
 };
 
 class LoggerUi {
@@ -37,6 +54,6 @@ private:
     ImGuiTextBuffer m_buf{};
     bool m_scroll_to_bottom{};
     std::shared_ptr<LoggerUiSink<std::mutex>> m_sink{
-        std::make_shared<LoggerUiSink<std::mutex>>(m_buf, m_scroll_to_bottom)};
+        std::make_shared<LoggerUiSink<std::mutex>>()};
     std::shared_ptr<spdlog::logger> m_logger{std::make_shared<spdlog::logger>("LoggerUi", m_sink)};
 };

--- a/src/ReGenny.cpp
+++ b/src/ReGenny.cpp
@@ -16,6 +16,7 @@
 #include <sdkgenny_parser.hpp>
 #include <spdlog/spdlog.h>
 
+#include "Api.hpp"
 #include "AboutUi.hpp"
 #include "Utility.hpp"
 #include "arch/Arch.hpp"
@@ -36,6 +37,7 @@ ReGenny::ReGenny(SDL_Window* window)
     spdlog::info("Start of log.");
 
     reset_lua_state();
+    m_api = std::make_unique<Api>(this);
 
     auto path_str = SDL_GetPrefPath("cursey", "ReGenny");
     m_app_path = path_str;
@@ -56,6 +58,7 @@ ReGenny::ReGenny(SDL_Window* window)
 }
 
 ReGenny::~ReGenny() {
+    m_api.reset();
 }
 
 void ReGenny::process_event(SDL_Event& e) {
@@ -92,6 +95,32 @@ void ReGenny::update() {
     if (m_cfg_save_time && now > *m_cfg_save_time) {
         save_cfg();
         m_cfg_save_time = std::nullopt;
+    }
+
+    // Process deferred API operations on the main thread.
+    if (m_api) {
+        if (m_api->should_reparse()) {
+            parse_file();
+        }
+        if (m_api->should_detach()) {
+            action_detach();
+        }
+        if (auto da = m_api->consume_deferred_attach()) {
+            m_project.process_id = da->pid;
+            m_project.process_name = da->name;
+            attach();
+        }
+        if (auto dopen = m_api->consume_deferred_open()) {
+            file_open(dopen->filepath);
+        }
+        if (auto dts = m_api->consume_deferred_type_select()) {
+            m_project.type_chosen = dts->type_name;
+            if (!dts->address.empty()) {
+                m_ui.address = dts->address;
+            }
+            set_type();
+            set_address();
+        }
     }
 }
 
@@ -497,6 +526,10 @@ void ReGenny::menu_ui() {
                 action_generate_sdk();
             }
 
+            if (ImGui::MenuItem("Generate IDA SDK")) {
+                action_generate_sdk(true);
+            }
+
             if (ImGui::MenuItem("Autogenerate RTTI Struct")) {
                 m_ui.rtti_text.clear();
                 ImGui::OpenPopup(m_ui.rtti_popup);
@@ -758,7 +791,7 @@ void ReGenny::action_detach() {
     set_window_title();
 }
 
-void ReGenny::action_generate_sdk() {
+void ReGenny::action_generate_sdk(bool ida) {
     if (m_sdk == nullptr) {
         return;
     }
@@ -770,6 +803,11 @@ void ReGenny::action_generate_sdk() {
     }
 
     spdlog::info("Generating SDK at {}...", sdk_path);
+
+    if (ida) {
+        genny::ida::transform(*m_sdk);
+    }
+    
     m_sdk->header_extension(m_project.extension_header)
         ->source_extension(m_project.extension_source)
         ->generate(sdk_path);

--- a/src/ReGenny.cpp
+++ b/src/ReGenny.cpp
@@ -37,13 +37,16 @@ ReGenny::ReGenny(SDL_Window* window)
     spdlog::info("Start of log.");
 
     reset_lua_state();
-    m_api = std::make_unique<Api>(this);
 
     auto path_str = SDL_GetPrefPath("cursey", "ReGenny");
     m_app_path = path_str;
     SDL_free(path_str);
 
     load_cfg();
+
+    if (m_cfg.api_enabled) {
+        m_api = std::make_unique<Api>(this);
+    }
 
     m_triggers.on({SDLK_LCTRL, SDLK_N}, [this] { file_new(); });
     m_triggers.on({SDLK_LCTRL, SDLK_O}, [this] { file_open(); });
@@ -566,6 +569,19 @@ void ReGenny::menu_ui() {
             if (ImGui::Checkbox("Always on top", &m_cfg.always_on_top)) {
                 save_cfg();
                 SDL_SetWindowAlwaysOnTop(m_window, m_cfg.always_on_top ? true : false);
+            }
+
+            if (ImGui::Checkbox("HTTP API (MCP)", &m_cfg.api_enabled)) {
+                save_cfg();
+                if (m_cfg.api_enabled && !m_api) {
+                    m_api = std::make_unique<Api>(this);
+                } else if (!m_cfg.api_enabled && m_api) {
+                    m_api.reset();
+                    spdlog::info("[API] HTTP server stopped.");
+                }
+            }
+            if (ImGui::IsItemHovered()) {
+                ImGui::SetTooltip("Enable/disable the HTTP API on localhost:12025 for MCP tool integration.");
             }
 
             ImGui::EndMenu();

--- a/src/ReGenny.cpp
+++ b/src/ReGenny.cpp
@@ -14,6 +14,9 @@
 #include <imgui_stdlib.h>
 #include <nfd.h>
 #include <sdkgenny_parser.hpp>
+// sdkgenny_ida.hpp uses bare sdkgenny names internally; the using-directive is confined to this TU.
+using namespace sdkgenny;
+#include <sdkgenny_ida.hpp>
 #include <spdlog/spdlog.h>
 
 #include "Api.hpp"
@@ -634,7 +637,7 @@ void ReGenny::file_new() {
         return;
     }
 
-    m_open_filepath = out_path;
+    { std::unique_lock lk{m_state_mtx}; m_open_filepath = out_path; }
     m_open_filepath.replace_extension("genny");
 
     free(out_path);
@@ -665,10 +668,10 @@ void ReGenny::file_open(const std::filesystem::path& filepath) {
             return;
         }
 
-        m_open_filepath = out_path;
+        { std::unique_lock lk{m_state_mtx}; m_open_filepath = out_path; }
         free(out_path);
     } else {
-        m_open_filepath = filepath;
+        std::unique_lock lk{m_state_mtx}; m_open_filepath = filepath;
     }
 
     spdlog::info("Opening {}...", m_open_filepath.string());
@@ -800,9 +803,12 @@ void ReGenny::file_run_lua_script() {
 
 void ReGenny::action_detach() {
     spdlog::info("Detaching...");
-    m_process = std::make_unique<Process>();
-    m_mem_ui = std::make_unique<MemoryUi>(
-        m_cfg, *m_sdk, dynamic_cast<sdkgenny::Struct*>(m_type), *m_process, m_project.props[m_project.type_chosen]);
+    {
+        std::unique_lock lk{m_state_mtx};
+        m_process = std::make_unique<Process>();
+        m_mem_ui = std::make_unique<MemoryUi>(
+            m_cfg, *m_sdk, dynamic_cast<sdkgenny::Struct*>(m_type), *m_process, m_project.props[m_project.type_chosen]);
+    }
     m_ui.processes.clear();
     set_window_title();
 }
@@ -894,8 +900,11 @@ void ReGenny::attach() {
 
     spdlog::info("Attaching to {} PID: {}...", m_project.process_name, m_project.process_id);
 
-    m_process = arch::open_process(m_project.process_id);
-    m_mem_ui = nullptr;
+    {
+        std::unique_lock lk{m_state_mtx};
+        m_process = arch::open_process(m_project.process_id);
+        m_mem_ui = nullptr;
+    }
 
     if (!m_process->ok()) {
         action_detach();
@@ -1300,6 +1309,7 @@ void ReGenny::rtti_ui() {
 }
 
 void ReGenny::update_address() {
+    std::unique_lock state_lk{m_state_mtx};
     // If the parsed address has no offsets then it's not valid at all and there's nothing to update.
     if (m_parsed_address.offsets.empty()) {
         return;
@@ -1437,7 +1447,10 @@ void ReGenny::set_type() {
         type_name.erase(0, pos + 1);
     }
 
-    m_type = parent->find<sdkgenny::Struct>(type_name);
+    {
+        std::unique_lock lk{m_state_mtx};
+        m_type = parent->find<sdkgenny::Struct>(type_name);
+    }
 
     if (m_type == nullptr) {
         return;
@@ -1960,11 +1973,14 @@ void ReGenny::parse_file() try {
             m_file_lwt = std::max(m_file_lwt, std::filesystem::last_write_time(import));
         }
 
-        m_sdk = std::move(sdk);
+        {
+            std::unique_lock lk{m_state_mtx};
+            m_sdk = std::move(sdk);
 
-        if (m_mem_ui != nullptr) {
-            m_project.props[m_project.type_chosen] = m_mem_ui->props();
-            m_mem_ui.reset();
+            if (m_mem_ui != nullptr) {
+                m_project.props[m_project.type_chosen] = m_mem_ui->props();
+                m_mem_ui.reset();
+            }
         }
 
         // Build the list of selectable types for the type selector.

--- a/src/ReGenny.hpp
+++ b/src/ReGenny.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <shared_mutex>
 #include <chrono>
 #include <deque>
 #include <filesystem>
@@ -10,8 +11,6 @@
 
 #include <SDL3/SDL.h>
 #include <sdkgenny.hpp>
-using namespace sdkgenny;
-#include <sdkgenny_ida.hpp>
 #include <sol/sol.hpp>
 
 #include "Config.hpp"
@@ -53,6 +52,10 @@ public:
     auto& lua_lock() { return m_lua_lock; }
     auto& lua() { return *m_lua; }
     void reset_lua_state_api() { reset_lua_state(); }
+
+    // Shared mutex for state accessed by the API thread.
+    // API handlers take shared (read) locks; main thread takes unique (write) locks at mutation points.
+    auto& state_mtx() { return m_state_mtx; }
 
     auto add_address_resolver(std::function<uintptr_t(const std::string&)> resolver) {
         auto id = m_address_resolvers.size();
@@ -153,6 +156,7 @@ private:
 
     Project m_project{};
     std::unique_ptr<Api> m_api;
+    std::shared_mutex m_state_mtx;
 
     void menu_ui();
 

--- a/src/ReGenny.hpp
+++ b/src/ReGenny.hpp
@@ -52,6 +52,7 @@ public:
     auto& lua_lock() { return m_lua_lock; }
     auto& lua() { return *m_lua; }
     void reset_lua_state_api() { reset_lua_state(); }
+    auto& logger() { return m_logger; }
 
     // Shared mutex for state accessed by the API thread.
     // API handlers take shared (read) locks; main thread takes unique (write) locks at mutation points.

--- a/src/ReGenny.hpp
+++ b/src/ReGenny.hpp
@@ -10,6 +10,8 @@
 
 #include <SDL3/SDL.h>
 #include <sdkgenny.hpp>
+using namespace sdkgenny;
+#include <sdkgenny_ida.hpp>
 #include <sol/sol.hpp>
 
 #include "Config.hpp"
@@ -21,6 +23,8 @@
 #include "Utility.hpp"
 #include "node/Property.hpp"
 #include "sdl_trigger.h"
+
+class Api;
 
 struct ModuleScanResult {
     std::string type_name;
@@ -38,11 +42,17 @@ public:
     void ui();
 
     auto&& window() const { return m_window; }
-    // auto& lua() const { return *m_lua; }
     auto& sdk() const { return m_sdk; }
     auto type() const { return m_type; }
     auto& process() const { return m_process; }
     auto address() const { return m_address; }
+
+    // API accessors — used by the embedded HTTP server (Api.cpp).
+    auto& open_filepath() const { return m_open_filepath; }
+    auto& project() const { return m_project; }
+    auto& lua_lock() { return m_lua_lock; }
+    auto& lua() { return *m_lua; }
+    void reset_lua_state_api() { reset_lua_state(); }
 
     auto add_address_resolver(std::function<uintptr_t(const std::string&)> resolver) {
         auto id = m_address_resolvers.size();
@@ -142,6 +152,7 @@ private:
     bool m_reapply_focus_eval{false};
 
     Project m_project{};
+    std::unique_ptr<Api> m_api;
 
     void menu_ui();
 
@@ -157,7 +168,7 @@ private:
     void file_run_lua_script();
 
     void action_detach();
-    void action_generate_sdk();
+    void action_generate_sdk(bool ida = false);
 
     void attach_ui();
     void attach();

--- a/src/node/Struct.cpp
+++ b/src/node/Struct.cpp
@@ -71,6 +71,10 @@ Struct::Struct(Config& cfg, Process& process, sdkgenny::Variable* var, Property&
             bitfield_type = var->type();
         }
 
+        if (bitfield_type == nullptr) {
+            continue;
+        }
+
         auto num_bits = bitfield_type->size() * CHAR_BIT;
 
         if (last_bit != num_bits) {

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -128,3 +128,16 @@ target_include_directories(scope_guard INTERFACE "scope_guard")
 add_library(SDL_Trigger STATIC "SDL_Trigger/SDL_Trigger.cpp")
 target_include_directories(SDL_Trigger INTERFACE "SDL_Trigger")
 target_link_libraries(SDL_Trigger PUBLIC SDL3::SDL3)
+
+
+# cpp-httplib
+CPMAddPackage(
+        NAME httplib
+        GITHUB_REPOSITORY yhirose/cpp-httplib
+        VERSION 0.18.3
+        DOWNLOAD_ONLY YES
+)
+if (httplib_ADDED)
+    add_library(httplib INTERFACE)
+    target_include_directories(httplib INTERFACE $<BUILD_INTERFACE:${httplib_SOURCE_DIR}>)
+endif ()


### PR DESCRIPTION
# Add MCP server for AI-assisted reverse engineering

Embeds a lightweight HTTP API in ReGenny and adds a .NET MCP (Model Context Protocol) server, enabling AI agents to drive the application programmatically — attach to processes, read/write memory, manipulate .genny files, execute Lua scripts, and inspect types.

## Architecture

```
AI Agent ──[MCP stdio]──> .NET MCP Server ──[HTTP localhost:12025]──> ReGenny (C++)
```

The HTTP API runs on a background thread inside ReGenny via [cpp-httplib](https://github.com/yhirose/cpp-httplib) (single-header, zero dependencies). The .NET MCP server is a thin stdio translation layer — it maps tool calls to HTTP requests and returns raw JSON. Zero business logic in the MCP layer.

## What's included

### C++ (embedded HTTP API)
- **`src/Api.hpp` / `src/Api.cpp`** — ~925 lines. 22 REST endpoints covering:
  - Process management (attach/detach/list)
  - Memory read/write (hex dump, typed reads, strings)
  - `.genny` file CRUD (get/set content, open, create, reload)
  - Type introspection (list types, get struct layout with fields/offsets/metadata)
  - Lua eval/exec with per-request output capture via spdlog sink
  - Project state and RTTI queries (Windows)
- **Config toggle** — `Options > HTTP API (MCP)` checkbox, on by default, persisted in `cfg.json`. Live toggle starts/stops the server without restart.
- **Thread safety** — UI-mutating operations (parse, attach, detach, file open, type select) are deferred to the main thread via atomic flags consumed in `update()`. Lua eval acquires the existing `m_lua_lock`. Process read/write uses Win32 APIs directly.

### .NET MCP Server (`mcp-server/`)
- **25 tools** across 7 categories: Status (5), Memory (5), Genny Files (5), Types (3), Lua (4), Project (1), RTTI (2)
- Attribute-based auto-discovery via `[McpServerTool]` + `WithToolsFromAssembly()`
- `REGENNY_API_URL` env var for port configuration

### Docs & Config
- **`AGENT.md`** — Navigation guide for AI agents: `.genny` format reference, Lua API, typical workflows, gotchas
- **`.mcp.json`** — Workspace MCP config for tool auto-discovery
- **`README.md`** — Added MCP integration section

## Build changes
- Added `cpp-httplib` v0.18.3 via CPM (header-only, MIT)
- Linked `httplib` to regenny target
- New `mcp-server/` .NET 10 project (ModelContextProtocol + Microsoft.Extensions.Hosting)

## Files changed

| File | Change |
|------|--------|
| `src/Api.hpp` | New |
| `src/Api.cpp` | New |
| `src/ReGenny.hpp` | Added Api member, public accessors for API use |
| `src/ReGenny.cpp` | Api lifecycle, deferred operations in update(), menu checkbox |
| `src/Config.hpp` | Added `api_enabled` field |
| `src/Config.cpp` | Serialization for `api_enabled` |
| `CMakeLists.txt` | Link httplib |
| `third_party/CMakeLists.txt` | Add cpp-httplib via CPM |
| `mcp-server/Program.cs` | New |
| `mcp-server/Http.cs` | New |
| `mcp-server/Tools.cs` | New |
| `mcp-server/McpServer.csproj` | New |
| `AGENT.md` | New |
| `.mcp.json` | New |
| `README.md` | Added MCP section |
